### PR TITLE
Persist the sequence number from the originating bounded context as t…

### DIFF
--- a/Source/Events/Relativity/Consumer/ParticleStreamProcessor.cs
+++ b/Source/Events/Relativity/Consumer/ParticleStreamProcessor.cs
@@ -66,6 +66,7 @@ namespace Dolittle.Runtime.Events.Relativity
         {
             try
             {
+                var originatingSequence = committedEventStreamWithContext.EventStream.Sequence;
                 var context = committedEventStreamWithContext.Context;
                 var particleStream = committedEventStreamWithContext.EventStream;
                 EventSourceVersion version = null;
@@ -113,7 +114,7 @@ namespace Dolittle.Runtime.Events.Relativity
                 {
                     committedEventStream = _.Commit(uncommittedEventStream);
                 }
-                SetOffset(_eventHorizonKey, committedEventStream.Sequence);
+                SetOffset(_eventHorizonKey, originatingSequence);
                 _logger.Information("Process committed events");
                 _processingHub.Process(committedEventStream);
                 return Task.FromResult(committedEventStream.Sequence);


### PR DESCRIPTION
…he geodesics offset, not the newly created one

fixes #238

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1115616103797671/1121521796819509)
