### PR TITLE
Changing to Dolittle.Common instead of import from submodule

### DIFF
--- a/Source/AggregatedPackage/Runtime.csproj
+++ b/Source/AggregatedPackage/Runtime.csproj
@@ -1,10 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="../../Build/MSBuild/default.props" />
-
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <AssemblyName>Dolittle.Runtime</AssemblyName>
     </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Dolittle.Common" Version="1.*" />
+    </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="../**/*.csproj" Exclude="../AggregatedPackage/Runtime.csproj;../Build/Build.csproj" />

--- a/Source/Applications.Configuration/Applications.Configuration.csproj
+++ b/Source/Applications.Configuration/Applications.Configuration.csproj
@@ -5,9 +5,8 @@
     <AssemblyName>Dolittle.Runtime.Applications.Configuration</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props"/>
-
   <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.Applications" Version="4.*" />
     <PackageReference Include="Dolittle.Booting" Version="4.*" />
     <PackageReference Include="Dolittle.Configuration" Version="4.*" />
@@ -16,5 +15,4 @@
     <PackageReference Include="Dolittle.ResourceTypes.Configuration" Version="4.*" />
     <PackageReference Include="Dolittle.Serialization.Json" Version="4.*" />
   </ItemGroup>
-
 </Project>

--- a/Source/Commands.Coordination/Commands.Coordination.csproj
+++ b/Source/Commands.Coordination/Commands.Coordination.csproj
@@ -5,8 +5,6 @@
     <AssemblyName>Dolittle.Runtime.Commands.Coordination</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props"></Import>
-
   <ItemGroup>
     <ProjectReference Include="..\Commands\Commands.csproj" />
     <ProjectReference Include="..\Commands.Handling\Commands.Handling.csproj" />
@@ -17,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.Applications" Version="4.*" />
     <PackageReference Include="Dolittle.Globalization" Version="4.*" />
   </ItemGroup>

--- a/Source/Commands.Handling/Commands.Handling.csproj
+++ b/Source/Commands.Handling/Commands.Handling.csproj
@@ -5,16 +5,14 @@
     <AssemblyName>Dolittle.Runtime.Commands.Handling</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props"></Import>
-
   <ItemGroup>
     <ProjectReference Include="..\Commands\Commands.csproj" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.Types" Version="4.*" />
     <PackageReference Include="Dolittle.Lifecycle" Version="4.*" />
     <PackageReference Include="Dolittle.Applications" Version="4.*" />
   </ItemGroup>
-
 </Project>

--- a/Source/Commands.Security/Commands.Security.csproj
+++ b/Source/Commands.Security/Commands.Security.csproj
@@ -5,14 +5,12 @@
     <AssemblyName>Dolittle.Runtime.Commands.Security</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props"></Import>
-
   <ItemGroup>
     <ProjectReference Include="..\Commands\Commands.csproj" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.Security" Version="4.*" />
   </ItemGroup>
-
 </Project>

--- a/Source/Commands.Validation/Commands.Validation.csproj
+++ b/Source/Commands.Validation/Commands.Validation.csproj
@@ -5,7 +5,9 @@
     <AssemblyName>Dolittle.Runtime.Commands.Validation</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props"></Import>
+  <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Commands\Commands.csproj" />

--- a/Source/Commands/Commands.csproj
+++ b/Source/Commands/Commands.csproj
@@ -5,16 +5,14 @@
     <AssemblyName>Dolittle.Runtime.Commands</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props"/>
-
   <ItemGroup>
     <ProjectReference Include="..\Transactions\Transactions.csproj" />
     <ProjectReference Include="..\Validation\Validation.csproj" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.Applications" Version="4.*" />
     <PackageReference Include="Dolittle.Execution" Version="4.*" />
   </ItemGroup>
-
 </Project>

--- a/Source/Events.Migration/Events.Migration.csproj
+++ b/Source/Events.Migration/Events.Migration.csproj
@@ -5,7 +5,9 @@
     <AssemblyName>Dolittle.Runtime.Events.Migration</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props" />
+  <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Events\Events.csproj" />

--- a/Source/Events/Events.csproj
+++ b/Source/Events/Events.csproj
@@ -6,9 +6,8 @@
     <RootNamespace>Dolittle.Runtime.Events</RootNamespace>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props" />
-
   <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.Applications" Version="4.*" />
     <PackageReference Include="Dolittle.Artifacts" Version="4.*" />
     <PackageReference Include="Dolittle.Booting" Version="4.*" />

--- a/Source/Heads.Management/Heads.Management.csproj
+++ b/Source/Heads.Management/Heads.Management.csproj
@@ -4,10 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Dolittle.Runtime.Heads.Management</AssemblyName>
   </PropertyGroup>
-
-  <Import Project="../../Build/MSBuild/default.props"/>
   
   <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.Management" Version="4.*"/>
     <PackageReference Include="Dolittle.Protobuf" Version="4.*"/>
     <PackageReference Include="Dolittle.Runtime.Management.Contracts" Version="4.*"/>

--- a/Source/Heads/Heads.csproj
+++ b/Source/Heads/Heads.csproj
@@ -4,13 +4,11 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Dolittle.Runtime.Heads</AssemblyName>
   </PropertyGroup>
-
-  <Import Project="../../Build/MSBuild/default.props"/>
-  
+ 
   <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.Services" Version="4.*"/>
     <PackageReference Include="Dolittle.Protobuf" Version="4.*"/>
     <PackageReference Include="Dolittle.Runtime.Contracts" Version="4.*"/>    
   </ItemGroup>
-
 </Project>

--- a/Source/Metrics/Metrics.csproj
+++ b/Source/Metrics/Metrics.csproj
@@ -5,13 +5,8 @@
     <AssemblyName>Dolittle.Runtime.Metrics</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props" />
-
   <ItemGroup>
-
-  </ItemGroup>
-
-  <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.Booting" Version="4.*" />
     <PackageReference Include="Dolittle.Configuration" Version="4.*" />
     <PackageReference Include="Dolittle.Types" Version="4.*" />

--- a/Source/Microservices/Microservices.csproj
+++ b/Source/Microservices/Microservices.csproj
@@ -5,9 +5,8 @@
     <AssemblyName>Dolittle.Runtime.Microservices</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props" />
-
   <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.Configuration" Version="4.*" />
     <PackageReference Include="Dolittle.Services" Version="4.*" />
   </ItemGroup>

--- a/Source/Protobuf/Protobuf.csproj
+++ b/Source/Protobuf/Protobuf.csproj
@@ -5,9 +5,8 @@
     <AssemblyName>Dolittle.Runtime.Protobuf</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props" />
-
   <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.Artifacts" Version="4.*" />
     <PackageReference Include="Dolittle.Execution" Version="4.*" />
     <PackageReference Include="Dolittle.PropertyBags" Version="4.*" />

--- a/Source/Queries.Coordination/Queries.Coordination.csproj
+++ b/Source/Queries.Coordination/Queries.Coordination.csproj
@@ -5,7 +5,9 @@
     <AssemblyName>Dolittle.Runtime.Queries.Coordination</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props" />
+  <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Queries\Queries.csproj" />

--- a/Source/Queries.Security/Queries.Security.csproj
+++ b/Source/Queries.Security/Queries.Security.csproj
@@ -5,9 +5,8 @@
     <AssemblyName>Dolittle.Runtime.Queries.Security</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props" />
-
   <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.Security" Version="4.*" />
   </ItemGroup>
 

--- a/Source/Queries.Validation/Queries.Validation.csproj
+++ b/Source/Queries.Validation/Queries.Validation.csproj
@@ -5,9 +5,8 @@
     <AssemblyName>Dolittle.Runtime.Queries.Validation</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props" />
-
   <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.Rules" Version="4.*" />
     <PackageReference Include="Dolittle.Lifecycle" Version="4.*" />
   </ItemGroup>

--- a/Source/Queries/Queries.csproj
+++ b/Source/Queries/Queries.csproj
@@ -5,9 +5,8 @@
     <AssemblyName>Dolittle.Runtime.Queries</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props" />
-
   <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.DependencyInversion" Version="4.*" />
     <PackageReference Include="Dolittle.Types" Version="4.*" />
     <PackageReference Include="Dolittle.Reflection" Version="4.*" />

--- a/Source/ReadModels/ReadModels.csproj
+++ b/Source/ReadModels/ReadModels.csproj
@@ -5,9 +5,8 @@
     <AssemblyName>Dolittle.Runtime.ReadModels</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props" />
-
   <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.ResourceTypes" Version="4.*" />
   </ItemGroup>
 

--- a/Source/Server/Server.csproj
+++ b/Source/Server/Server.csproj
@@ -5,14 +5,13 @@
     <AssemblyName>Dolittle.Runtime.Server</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props" />
-
   <ItemGroup>
     <ProjectReference Include="../Heads/Heads.csproj"/>
     <ProjectReference Include="../Heads.Management/Heads.Management.csproj"/>
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.Booting" Version="4.*" />
     <PackageReference Include="Dolittle.Configuration.Files" Version="4.*" />
     <PackageReference Include="Dolittle.Concepts.Serialization.Json" Version="4.*" />

--- a/Source/Tasks/Tasks.csproj
+++ b/Source/Tasks/Tasks.csproj
@@ -5,9 +5,8 @@
     <AssemblyName>Dolittle.Runtime.Read</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props" />
-
   <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.Collections" Version="4.*" />
     <PackageReference Include="Dolittle.Execution" Version="4.*" />
     <PackageReference Include="Dolittle.Types" Version="4.*" />

--- a/Source/Tenancy/Tenancy.csproj
+++ b/Source/Tenancy/Tenancy.csproj
@@ -4,10 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Dolittle.Runtime.Tenancy</AssemblyName>
   </PropertyGroup>
-
-  <Import Project="../../Build/MSBuild/default.props"/>
   
   <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.Configuration" Version="4.*" />
     <PackageReference Include="Dolittle.Tenancy" Version="4.*" />
     <PackageReference Include="Dolittle.Types" Version="4.*" />

--- a/Source/Transactions/Transactions.csproj
+++ b/Source/Transactions/Transactions.csproj
@@ -5,9 +5,8 @@
     <AssemblyName>Dolittle.Runtime.Transactions</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props"/>
-
   <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.Concepts" Version="4.*"/>
   </ItemGroup>
 

--- a/Source/Validation/Validation.csproj
+++ b/Source/Validation/Validation.csproj
@@ -5,9 +5,8 @@
     <AssemblyName>Dolittle.Runtime.Validation</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="../../Build/MSBuild/default.props" />
-
   <ItemGroup>
+    <PackageReference Include="Dolittle.Common" Version="1.*" />
     <PackageReference Include="Dolittle.Rules" Version="4.*" />
     <PackageReference Include="Dolittle.Types" Version="4.*" />
     <PackageReference Include="Dolittle.Reflection" Version="4.*" />


### PR DESCRIPTION
First step of finally getting rid of the Git Submodule for Build