### PR TITLE
Add index file to have an overview of the building blocks section

### DIFF
--- a/Documentation/_index.md
+++ b/Documentation/_index.md
@@ -1,0 +1,15 @@
+---
+title: Building blocks
+description: The essential building blocks of the Dolittle framework
+author: Dolittle
+keywords: runtime, sdk, fundamentals, concepts, building, block, essentials
+weight: 20
+type: "space"
+icon: "ti-package"
+repository: https://github.com/dolittle-runtime/Runtime
+aliases:
+    - /runtime
+---
+
+The Dolittle [runtime](https://github.com/dolittle-runtime/Runtime) provides you with: [Commands]({{< ref about_commands >}}), [Events]({{< ref domain_events >}}), [ReadModels]({{< ref read_model >}}), [Events]({{< ref query >}}), [metrics]({{< ref metrics >}}), [tenancy]({{< ref tenancy_system >}}) and [resource management]({{< ref resources >}}) systems to build web apps.
+

--- a/Documentation/_index.md
+++ b/Documentation/_index.md
@@ -11,5 +11,14 @@ aliases:
     - /runtime
 ---
 
+This section documents the main building blocks of a Dolittle application. It covers both the backend and the front end.
+
+To learn how to write a Dolittle application read our [tutorial.]({{< ref "/getting-started/tutorial/setup" >}})
+
+For a more high-level explanation read our [overview.]({{< ref "/getting-started/overview" >}})
+
+
 The Dolittle [runtime](https://github.com/dolittle-runtime/Runtime) provides you with: [Commands]({{< ref about_commands >}}), [Events]({{< ref domain_events >}}), [ReadModels]({{< ref read_model >}}), [Events]({{< ref query >}}), [metrics]({{< ref metrics >}}), [tenancy]({{< ref tenancy_system >}}) and [resource management]({{< ref resources >}}) systems to build web apps.
+
+
 


### PR DESCRIPTION
As Runtime makes up most of the concepts found in "Building blocks" it makes sense that it takes ownership of the toplevel index file.

Also this way the github edit links are all correct for the Runtime repo, including the topmost index file (aka the one I'm adding right now)

Should be merged together with https://github.com/dolittle/Documentation/pull/68

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1164932785929085)
