### PR TITLE
Make CancellationToken non-optional parameter 

### DIFF
--- a/Source/EventHorizon/Consumer/ConsumerClient.cs
+++ b/Source/EventHorizon/Consumer/ConsumerClient.cs
@@ -139,10 +139,9 @@ namespace Dolittle.Runtime.EventHorizon.Consumer
         async Task<AsyncServerStreamingCall<grpc.SubscriptionStreamMessage>> Subscribe(Subscription subscription, MicroserviceAddress microserviceAddress)
         {
             _logger.Debug($"Tenant '{subscription.ConsumerTenant}' is subscribing to events from tenant '{subscription.ProducerTenant}' in microservice '{subscription.ProducerMicroservice}' on address '{microserviceAddress.Host}:{microserviceAddress.Port}'");
-            var currentStreamProcessorState = await _streamProcessorStates.GetOrAddNew(new StreamProcessorId(
-                                                                                        subscription.Scope,
-                                                                                        subscription.ProducerTenant.Value,
-                                                                                        subscription.ProducerMicroservice.Value)).ConfigureAwait(false);
+            var currentStreamProcessorState = await _streamProcessorStates.GetOrAddNew(
+                new StreamProcessorId(subscription.Scope, subscription.ProducerTenant.Value, subscription.ProducerMicroservice.Value),
+                _token).ConfigureAwait(false);
             var publicEventsPosition = currentStreamProcessorState.Position;
             return _clientManager
                 .Get<grpc.Consumer.ConsumerClient>(microserviceAddress.Host, microserviceAddress.Port)

--- a/Source/EventHorizon/Consumer/EventsFromEventHorizonFetcher.cs
+++ b/Source/EventHorizon/Consumer/EventsFromEventHorizonFetcher.cs
@@ -31,11 +31,11 @@ namespace Dolittle.Runtime.EventHorizon.Consumer
             _events.DequeueAsync(cancellationToken);
 
         /// <inheritdoc/>
-        public Task<IEnumerable<StreamEvent>> FetchRange(ScopeId scopeId, StreamId streamId, StreamPositionRange range, CancellationToken cancellationToken = default) =>
+        public Task<IEnumerable<StreamEvent>> FetchRange(ScopeId scopeId, StreamId streamId, StreamPositionRange range, CancellationToken cancellationToken) =>
             throw new CannotFetchRangeOfEventsFromEventHorizon();
 
         /// <inheritdoc/>
-        public Task<StreamPosition> FindNext(ScopeId scopeId, StreamId streamId, PartitionId partitionId, StreamPosition fromPosition, CancellationToken cancellationToken = default) =>
+        public Task<StreamPosition> FindNext(ScopeId scopeId, StreamId streamId, PartitionId partitionId, StreamPosition fromPosition, CancellationToken cancellationToken) =>
             Task.FromResult<StreamPosition>(uint.MaxValue);
     }
 }

--- a/Source/EventHorizon/Consumer/IWriteEventHorizonEvents.cs
+++ b/Source/EventHorizon/Consumer/IWriteEventHorizonEvents.cs
@@ -19,6 +19,6 @@ namespace Dolittle.Runtime.EventHorizon.Consumer
         /// <param name="scope">The <see cref="ScopeId" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The task.</returns>
-        Task Write(CommittedEvent @event, ScopeId scope, CancellationToken cancellationToken = default);
+        Task Write(CommittedEvent @event, ScopeId scope, CancellationToken cancellationToken);
     }
 }

--- a/Source/EventHorizon/Producer/Filter/IWriteEventsToPublicStreams.cs
+++ b/Source/EventHorizon/Producer/Filter/IWriteEventsToPublicStreams.cs
@@ -21,6 +21,6 @@ namespace Dolittle.Runtime.EventHorizon.Producer.Filter
         /// <param name="partitionId">The <see cref="PartitionId" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>A <see cref="Task"/> representing whether the event was successfully written to the event store.</returns>
-        Task Write(CommittedEvent @event, StreamId streamId, PartitionId partitionId, CancellationToken cancellationToken = default);
+        Task Write(CommittedEvent @event, StreamId streamId, PartitionId partitionId, CancellationToken cancellationToken);
     }
 }

--- a/Source/EventHorizon/Producer/Filter/PublicFilterValidator.cs
+++ b/Source/EventHorizon/Producer/Filter/PublicFilterValidator.cs
@@ -27,7 +27,7 @@ namespace Dolittle.Runtime.EventHorizon.Producer.Filter
         }
 
         /// <inheritdoc/>
-        public Task Validate(IFilterProcessor<PublicFilterDefinition> filter, CancellationToken cancellationToken = default) =>
+        public Task Validate(IFilterProcessor<PublicFilterDefinition> filter, CancellationToken cancellationToken) =>
             Task.CompletedTask;
     }
 }

--- a/Source/EventHorizon/Producer/IFetchEventsFromPublicStreams.cs
+++ b/Source/EventHorizon/Producer/IFetchEventsFromPublicStreams.cs
@@ -20,7 +20,7 @@ namespace Dolittle.Runtime.EventHorizon.Producer
         /// <param name="streamPosition"><see cref="StreamPosition">the position in the stream</see>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The <see cref="StreamEvent" />.</returns>
-        Task<StreamEvent> Fetch(StreamId streamId, StreamPosition streamPosition, CancellationToken cancellationToken = default);
+        Task<StreamEvent> Fetch(StreamId streamId, StreamPosition streamPosition, CancellationToken cancellationToken);
 
         /// <summary>
         /// Fetch a range of events from a position to another in a stream.
@@ -29,7 +29,7 @@ namespace Dolittle.Runtime.EventHorizon.Producer
         /// <param name="range">The <see cref="StreamPositionRange" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The <see cref="IEnumerable{T}" /> of <see cref="StreamEvent" />.</returns>
-        Task<IEnumerable<StreamEvent>> FetchRange(StreamId streamId, StreamPositionRange range, CancellationToken cancellationToken = default);
+        Task<IEnumerable<StreamEvent>> FetchRange(StreamId streamId, StreamPositionRange range, CancellationToken cancellationToken);
 
         /// <summary>
         /// Finds the <see cref="StreamPosition" /> of the next event to process in a <see cref="StreamId" /> for a <see cref="PartitionId" />.
@@ -39,6 +39,6 @@ namespace Dolittle.Runtime.EventHorizon.Producer
         /// <param name="fromPosition">The <see cref="StreamPosition" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The <see cref="StreamPosition" />of the next event to process.</returns>
-        Task<StreamPosition> FindNext(StreamId streamId, PartitionId partitionId, StreamPosition fromPosition, CancellationToken cancellationToken = default);
+        Task<StreamPosition> FindNext(StreamId streamId, PartitionId partitionId, StreamPosition fromPosition, CancellationToken cancellationToken);
     }
 }

--- a/Source/Events.Processing/EventHandlers/EventProcessor.cs
+++ b/Source/Events.Processing/EventHandlers/EventProcessor.cs
@@ -57,7 +57,7 @@ namespace Dolittle.Runtime.Events.Processing.EventHandlers
 
         #nullable enable
         /// <inheritdoc />
-        public async Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, RetryProcessingState? retryProcessingState, CancellationToken cancellationToken = default)
+        public async Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, RetryProcessingState? retryProcessingState, CancellationToken cancellationToken)
         {
             _logger.Debug($"{_logMessagePrefix} is processing event '{@event.Type.Id.Value}' for partition '{partitionId.Value}'");
 

--- a/Source/Events.Processing/Filters/AbstractFilterProcessor.cs
+++ b/Source/Events.Processing/Filters/AbstractFilterProcessor.cs
@@ -58,7 +58,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         public abstract Task<IFilterResult> Filter(CommittedEvent @event, PartitionId partitionId, EventProcessorId eventProcessorId, grpc.RetryProcessingState? retryProcessingState, CancellationToken cancellationToken);
 
         /// <inheritdoc />
-        public async Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, grpc.RetryProcessingState? retryProcessingState, CancellationToken cancellationToken = default)
+        public async Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, grpc.RetryProcessingState? retryProcessingState, CancellationToken cancellationToken)
         {
             _logger.Debug($"{_logMessagePrefix} is filtering event '{@event.Type.Id}' for partition '{partitionId}'");
             var result = await Filter(@event, partitionId, Identifier, retryProcessingState, cancellationToken).ConfigureAwait(false);

--- a/Source/Events.Processing/Filters/FilterRegistry.cs
+++ b/Source/Events.Processing/Filters/FilterRegistry.cs
@@ -41,7 +41,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         }
 
         /// <inheritdoc/>
-        public async Task Register<TDefinition>(IFilterProcessor<TDefinition> filter, CancellationToken cancellationToken = default)
+        public async Task Register<TDefinition>(IFilterProcessor<TDefinition> filter, CancellationToken cancellationToken)
             where TDefinition : IFilterDefinition
         {
             _logger.Debug($"Registering filter defintion of type {typeof(TDefinition).FullName} on source stream '{filter.Definition.SourceStream}' and target stream '{filter.Definition.TargetStream}'");
@@ -73,7 +73,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         }
 
         /// <inheritdoc/>
-        public Task RemoveIfPersisted(ScopeId scope, StreamId targetStream, CancellationToken cancellationToken = default)
+        public Task RemoveIfPersisted(ScopeId scope, StreamId targetStream, CancellationToken cancellationToken)
         {
             _logger.Debug($"Removing persisted filter definition on target stream '{targetStream}' if persisted");
             if (!_registeredFilters.TryGetValue(targetStream, out var filterProcessor)) throw new NoFilterRegisteredForStream(scope, targetStream);

--- a/Source/Events.Processing/Filters/FilterValidators.cs
+++ b/Source/Events.Processing/Filters/FilterValidators.cs
@@ -29,7 +29,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         }
 
         /// <inheritdoc/>
-        public Task Validate<TDefinition>(IFilterProcessor<TDefinition> filter, CancellationToken cancellationToken = default)
+        public Task Validate<TDefinition>(IFilterProcessor<TDefinition> filter, CancellationToken cancellationToken)
             where TDefinition : IFilterDefinition
         {
             _logger.Debug($"Validating filter with filter definition type {typeof(TDefinition).FullName}");

--- a/Source/Events.Processing/Filters/Filters.cs
+++ b/Source/Events.Processing/Filters/Filters.cs
@@ -113,7 +113,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
                     _executionContextManager.CurrentFor(tenant);
                     var filter = createFilter();
                     await _filterRegistryFactory().Register(filter, cancellationToken).ConfigureAwait(false);
-                    _streamProcessorsFactory().Register(filter, _eventsFromStreamsFetcherFactory(), sourceStream);
+                    _streamProcessorsFactory().Register(filter, _eventsFromStreamsFetcherFactory(), sourceStream, cancellationToken);
                 }
                 catch (IllegalFilterTransformation ex)
                 {

--- a/Source/Events.Processing/Filters/ICanRemovePersistedFilterDefinition.cs
+++ b/Source/Events.Processing/Filters/ICanRemovePersistedFilterDefinition.cs
@@ -18,6 +18,6 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         /// <param name="targetStream">The target <see cref="StreamId" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The task of removing a persisted filter.</returns>
-        Task RemovePersistedFilter(StreamId targetStream, CancellationToken cancellationToken = default);
+        Task RemovePersistedFilter(StreamId targetStream, CancellationToken cancellationToken);
     }
 }

--- a/Source/Events.Processing/Filters/ICanValidateFilterFor.cs
+++ b/Source/Events.Processing/Filters/ICanValidateFilterFor.cs
@@ -19,6 +19,6 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         /// <param name="filter">The <see cref="IFilterProcessor{TDefinition}" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The async operation of validating a filter.</returns>
-        Task Validate(IFilterProcessor<TDefinition> filter, CancellationToken cancellationToken = default);
+        Task Validate(IFilterProcessor<TDefinition> filter, CancellationToken cancellationToken);
     }
 }

--- a/Source/Events.Processing/Filters/IFilterDefinitionRepositoryFor.cs
+++ b/Source/Events.Processing/Filters/IFilterDefinitionRepositoryFor.cs
@@ -19,7 +19,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         /// <param name="filterDefinition">The <see cref="IFilterDefinition" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The task of adding a persisted filter.</returns>
-        Task PersistFilter(TDefinition filterDefinition, CancellationToken cancellationToken = default);
+        Task PersistFilter(TDefinition filterDefinition, CancellationToken cancellationToken);
 
         /// <summary>
         /// Gets the persisted <see cref="IFilterDefinition" />.
@@ -27,6 +27,6 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         /// <param name="filterDefinition">The <see cref="IFilterDefinition" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The persisted filter definition or null if is not persisted.</returns>
-        Task<TDefinition> GetPersistedFilter(TDefinition filterDefinition, CancellationToken cancellationToken = default);
+        Task<TDefinition> GetPersistedFilter(TDefinition filterDefinition, CancellationToken cancellationToken);
     }
 }

--- a/Source/Events.Processing/Filters/IFilterRegistry.cs
+++ b/Source/Events.Processing/Filters/IFilterRegistry.cs
@@ -20,7 +20,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         /// <param name="filter">The <see cref="IFilterProcessor{TDefinition}" /> filter.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The task of registering the filter.</returns>
-        Task Register<TDefinition>(IFilterProcessor<TDefinition> filter, CancellationToken cancellationToken = default)
+        Task Register<TDefinition>(IFilterProcessor<TDefinition> filter, CancellationToken cancellationToken)
             where TDefinition : IFilterDefinition;
 
         /// <summary>
@@ -37,6 +37,6 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         /// <param name="targetStream">The target <see cref="StreamId"/> of the filter to remove.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The task of removing a persisted filter.</returns>
-        Task RemoveIfPersisted(ScopeId scope, StreamId targetStream, CancellationToken cancellationToken = default);
+        Task RemoveIfPersisted(ScopeId scope, StreamId targetStream, CancellationToken cancellationToken);
     }
 }

--- a/Source/Events.Processing/Filters/IFilterValidators.cs
+++ b/Source/Events.Processing/Filters/IFilterValidators.cs
@@ -18,7 +18,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         /// <param name="filter">The <see cref="IFilterProcessor{TDefinition}" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The async operation of validating a filter.</returns>
-        Task Validate<TDefinition>(IFilterProcessor<TDefinition> filter, CancellationToken cancellationToken = default)
+        Task Validate<TDefinition>(IFilterProcessor<TDefinition> filter, CancellationToken cancellationToken)
             where TDefinition : IFilterDefinition;
     }
 }

--- a/Source/Events.Processing/Filters/RemoteFilterValidator.cs
+++ b/Source/Events.Processing/Filters/RemoteFilterValidator.cs
@@ -40,7 +40,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         }
 
         /// <inheritdoc/>
-        public async Task Validate(IFilterProcessor<RemoteFilterDefinition> filter, CancellationToken cancellationToken = default)
+        public async Task Validate(IFilterProcessor<RemoteFilterDefinition> filter, CancellationToken cancellationToken)
         {
             var streamProcessorState = await _streamProcessorStateRepository.GetOrAddNew(new StreamProcessorId(filter.Scope, filter.Definition.TargetStream.Value, filter.Definition.SourceStream), cancellationToken).ConfigureAwait(false);
             var lastUnProcessedEventPosition = streamProcessorState.Position;

--- a/Source/Events.Processing/Filters/TypeFilterWithEventSourcePartitionValidator.cs
+++ b/Source/Events.Processing/Filters/TypeFilterWithEventSourcePartitionValidator.cs
@@ -48,7 +48,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
         }
 
         /// <inheritdoc/>
-        public Task Validate(IFilterProcessor<TypeFilterWithEventSourcePartitionDefinition> filter, CancellationToken cancellationToken = default) =>
+        public Task Validate(IFilterProcessor<TypeFilterWithEventSourcePartitionDefinition> filter, CancellationToken cancellationToken) =>
             ValidateBasedOffReFilteredStream(filter, cancellationToken);
 
         async Task ValidateBasedOffReFilteredStream(IFilterProcessor<TypeFilterWithEventSourcePartitionDefinition> filter, CancellationToken cancellationToken)

--- a/Source/Events.Processing/IEventProcessor.cs
+++ b/Source/Events.Processing/IEventProcessor.cs
@@ -35,6 +35,6 @@ namespace Dolittle.Runtime.Events.Processing
         /// <param name="retryProcessingState"><see cref="grpc.RetryProcessingState" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns><see cref="IProcessingResult" />.</returns>
-        Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, grpc.RetryProcessingState? retryProcessingState, CancellationToken cancellationToken = default);
+        Task<IProcessingResult> Process(CommittedEvent @event, PartitionId partitionId, grpc.RetryProcessingState? retryProcessingState, CancellationToken cancellationToken);
     }
 }

--- a/Source/Events.Processing/Streams/FailingPartitions.cs
+++ b/Source/Events.Processing/Streams/FailingPartitions.cs
@@ -40,16 +40,16 @@ namespace Dolittle.Runtime.Events.Processing.Streams
         }
 
         /// <inheritdoc/>
-        public Task<StreamProcessorState> AddFailingPartitionFor(StreamProcessorId streamProcessorId, PartitionId partition, StreamPosition position, ProcessorFailureType failureType, DateTimeOffset retryTime, string reason, CancellationToken cancellationToken = default)
+        public Task<StreamProcessorState> AddFailingPartitionFor(StreamProcessorId streamProcessorId, PartitionId partition, StreamPosition position, ProcessorFailureType failureType, DateTimeOffset retryTime, string reason, CancellationToken cancellationToken)
         {
             _logger.Debug($"Adding failing partition '{partition}' with retry time '{retryTime}' to stream processor '{streamProcessorId}' because of: {reason}");
             return _streamProcessorStates.AddFailingPartition(streamProcessorId, partition, position, failureType, retryTime, reason, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task<StreamProcessorState> CatchupFor(StreamProcessorId streamProcessorId, IEventProcessor eventProcessor, StreamProcessorState streamProcessorState, CancellationToken cancellationToken = default)
+        public async Task<StreamProcessorState> CatchupFor(StreamProcessorId streamProcessorId, IEventProcessor eventProcessor, StreamProcessorState streamProcessorState, CancellationToken cancellationToken)
         {
-            if (streamProcessorState.FailingPartitions.Count > 0) streamProcessorState = await _streamProcessorStates.GetOrAddNew(streamProcessorId).ConfigureAwait(false);
+            if (streamProcessorState.FailingPartitions.Count > 0) streamProcessorState = await _streamProcessorStates.GetOrAddNew(streamProcessorId, cancellationToken).ConfigureAwait(false);
             var failingPartitionsList = streamProcessorState.FailingPartitions.ToList();
             foreach (var kvp in failingPartitionsList)
             {

--- a/Source/Events.Processing/Streams/IFailingPartitions.cs
+++ b/Source/Events.Processing/Streams/IFailingPartitions.cs
@@ -24,7 +24,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams
         /// <param name="reason">The reason it failed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The new <see cref="StreamProcessorState" />.</returns>
-        Task<StreamProcessorState> AddFailingPartitionFor(StreamProcessorId streamProcessorId, PartitionId partition, StreamPosition position, ProcessorFailureType failureType, DateTimeOffset retryTime, string reason, CancellationToken cancellationToken = default);
+        Task<StreamProcessorState> AddFailingPartitionFor(StreamProcessorId streamProcessorId, PartitionId partition, StreamPosition position, ProcessorFailureType failureType, DateTimeOffset retryTime, string reason, CancellationToken cancellationToken);
 
         /// <summary>
         /// Catchup all failing partitions for a <see cref="StreamProcessor" />.
@@ -34,6 +34,6 @@ namespace Dolittle.Runtime.Events.Processing.Streams
         /// <param name="streamProcessorState">The current <see cref="StreamProcessorState" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The new <see cref="StreamProcessorState" />.</returns>
-        Task<StreamProcessorState> CatchupFor(StreamProcessorId streamProcessorId, IEventProcessor eventProcessor, StreamProcessorState streamProcessorState, CancellationToken cancellationToken = default);
+        Task<StreamProcessorState> CatchupFor(StreamProcessorId streamProcessorId, IEventProcessor eventProcessor, StreamProcessorState streamProcessorState, CancellationToken cancellationToken);
     }
 }

--- a/Source/Events.Processing/Streams/IStreamProcessorStateRepository.cs
+++ b/Source/Events.Processing/Streams/IStreamProcessorStateRepository.cs
@@ -19,7 +19,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams
         /// <param name="streamProcessorId">The unique<see cref="StreamProcessorId" /> key representing the <see cref="StreamProcessor"/>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The persisted <see cref="StreamProcessorState" />for this <see cref="StreamProcessor" />.</returns>
-        Task<StreamProcessorState> GetOrAddNew(StreamProcessorId streamProcessorId, CancellationToken cancellationToken = default);
+        Task<StreamProcessorState> GetOrAddNew(StreamProcessorId streamProcessorId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Sets the <see cref="StreamPosition" /> to point to the next event to process for a <see cref="StreamProcessor" />.
@@ -28,7 +28,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams
         /// <param name="nextEventToProcessPosition">The <see cref="StreamPosition" /> of the next event to process.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The persisted <see cref="StreamProcessorState" />for this <see cref="StreamProcessor" />.</returns>
-        Task<StreamProcessorState> SetNextEventToProcessPosition(StreamProcessorId streamProcessorId, StreamPosition nextEventToProcessPosition, CancellationToken cancellationToken = default);
+        Task<StreamProcessorState> SetNextEventToProcessPosition(StreamProcessorId streamProcessorId, StreamPosition nextEventToProcessPosition, CancellationToken cancellationToken);
 
         /// <summary>
         /// Adds a failing partition to the state.
@@ -41,7 +41,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams
         /// <param name="reason">The reason for failure.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The persisted <see cref="StreamProcessorState" />for this <see cref="StreamProcessor" />.</returns>
-        Task<StreamProcessorState> AddFailingPartition(StreamProcessorId streamProcessorId, PartitionId partitionId, StreamPosition position, ProcessorFailureType failureType, DateTimeOffset retryTime, string reason, CancellationToken cancellationToken = default);
+        Task<StreamProcessorState> AddFailingPartition(StreamProcessorId streamProcessorId, PartitionId partitionId, StreamPosition position, ProcessorFailureType failureType, DateTimeOffset retryTime, string reason, CancellationToken cancellationToken);
 
         /// <summary>
         /// Adds a failing partition to the state.
@@ -50,7 +50,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams
         /// <param name="partitionId">The <see cref="PartitionId" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The persisted <see cref="StreamProcessorState" />for this <see cref="StreamProcessor" />.</returns>
-        Task<StreamProcessorState> RemoveFailingPartition(StreamProcessorId streamProcessorId, PartitionId partitionId, CancellationToken cancellationToken = default);
+        Task<StreamProcessorState> RemoveFailingPartition(StreamProcessorId streamProcessorId, PartitionId partitionId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Sets the <see cref="FailingPartitionState" /> of for a partition.
@@ -60,6 +60,6 @@ namespace Dolittle.Runtime.Events.Processing.Streams
         /// <param name="failingPartitionState">The <see cref="FailingPartitionState" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The persisted <see cref="StreamProcessorState" />for this <see cref="StreamProcessor" />.</returns>
-        Task<StreamProcessorState> SetFailingPartitionState(StreamProcessorId streamProcessorId, PartitionId partitionId, FailingPartitionState failingPartitionState, CancellationToken cancellationToken = default);
+        Task<StreamProcessorState> SetFailingPartitionState(StreamProcessorId streamProcessorId, PartitionId partitionId, FailingPartitionState failingPartitionState, CancellationToken cancellationToken);
     }
 }

--- a/Source/Events.Processing/Streams/IStreamProcessorStates.cs
+++ b/Source/Events.Processing/Streams/IStreamProcessorStates.cs
@@ -23,7 +23,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams
         /// <param name="streamProcessorId">The <see cref="StreamProcessorId" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The stored <see cref="StreamProcessorState" />.</returns>
-        Task<StreamProcessorState> GetStoredStateFor(StreamProcessorId streamProcessorId, CancellationToken cancellationToken = default);
+        Task<StreamProcessorState> GetStoredStateFor(StreamProcessorId streamProcessorId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Handles the processing an event for a <see cref="StreamProcessor" /> by changing the <see cref="StreamProcessorState" /> of the <see cref="StreamProcessor" /> according to the result of the processing.
@@ -34,6 +34,6 @@ namespace Dolittle.Runtime.Events.Processing.Streams
         /// <param name="currentState">The current <see cref="StreamProcessorState" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The new <see cref="StreamProcessorState" />.</returns>
-        Task<StreamProcessorState> ProcessEventAndChangeStateFor(StreamProcessorId streamProcessorId, IEventProcessor eventProcessor, StreamEvent streamEvent, StreamProcessorState currentState, CancellationToken cancellationToken = default);
+        Task<StreamProcessorState> ProcessEventAndChangeStateFor(StreamProcessorId streamProcessorId, IEventProcessor eventProcessor, StreamEvent streamEvent, StreamProcessorState currentState, CancellationToken cancellationToken);
     }
 }

--- a/Source/Events.Processing/Streams/IStreamProcessors.cs
+++ b/Source/Events.Processing/Streams/IStreamProcessors.cs
@@ -27,7 +27,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams
         /// <param name="sourceStreamId">The <see cref="StreamId" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The <see cref="StreamProcessorRegistrationResult"/>.</returns>
-        StreamProcessorRegistrationResult Register(IEventProcessor eventProcessor, IFetchEventsFromStreams eventsFromStreamsFetcher, StreamId sourceStreamId, CancellationToken cancellationToken = default);
+        StreamProcessorRegistrationResult Register(IEventProcessor eventProcessor, IFetchEventsFromStreams eventsFromStreamsFetcher, StreamId sourceStreamId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Unregister a <see cref="IEventProcessor"/> from stream processing.

--- a/Source/Events.Processing/Streams/StreamProcessor.cs
+++ b/Source/Events.Processing/Streams/StreamProcessor.cs
@@ -46,7 +46,7 @@ namespace Dolittle.Runtime.Events.Processing.Streams
             IFetchEventsFromStreams eventsFromStreamsFetcher,
             IStreamProcessors streamProcessors,
             ILogger logger,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
         {
             _processor = processor;
             _eventsFromStreamsFetcher = eventsFromStreamsFetcher;

--- a/Source/Events.Processing/Streams/StreamProcessorStates.cs
+++ b/Source/Events.Processing/Streams/StreamProcessorStates.cs
@@ -37,14 +37,14 @@ namespace Dolittle.Runtime.Events.Processing.Streams
         public IFailingPartitions FailingPartitions { get; }
 
         /// <inheritdoc/>.
-        public Task<StreamProcessorState> GetStoredStateFor(StreamProcessorId streamProcessorId, CancellationToken cancellationToken = default)
+        public Task<StreamProcessorState> GetStoredStateFor(StreamProcessorId streamProcessorId, CancellationToken cancellationToken)
         {
             _logger.Debug($"Getting stored stream processor state for Stream Processor '{streamProcessorId}'");
             return _streamProcessorStates.GetOrAddNew(streamProcessorId, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task<StreamProcessorState> ProcessEventAndChangeStateFor(StreamProcessorId streamProcessorId, IEventProcessor eventProcessor, StreamEvent streamEvent, StreamProcessorState currentState, CancellationToken cancellationToken = default)
+        public async Task<StreamProcessorState> ProcessEventAndChangeStateFor(StreamProcessorId streamProcessorId, IEventProcessor eventProcessor, StreamEvent streamEvent, StreamProcessorState currentState, CancellationToken cancellationToken)
         {
             if (currentState.FailingPartitions.Keys.Contains(streamEvent.Partition))
             {

--- a/Source/Events.Store.MongoDB/Aggregates/AggregateRoots.cs
+++ b/Source/Events.Store.MongoDB/Aggregates/AggregateRoots.cs
@@ -33,7 +33,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Aggregates
             ArtifactId aggregateRoot,
             AggregateRootVersion expectedVersion,
             AggregateRootVersion nextVersion,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
         {
             ThrowIfNextVersionIsNotGreaterThanExpectedVersion(expectedVersion, nextVersion);
 
@@ -64,7 +64,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Aggregates
             IClientSessionHandle transaction,
             EventSourceId eventSource,
             ArtifactId aggregateRoot,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
         {
             var eqFilter = _filter.Eq(_ => _.EventSource, eventSource.Value)
                 & _filter.Eq(_ => _.AggregateType, aggregateRoot.Value);
@@ -86,7 +86,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Aggregates
             ArtifactId aggregateRoot,
             AggregateRootVersion expectedVersion,
             AggregateRootVersion nextVersion,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
         {
             try
             {
@@ -145,7 +145,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Aggregates
             ArtifactId aggregateRoot,
             AggregateRootVersion expectedVersion,
             AggregateRootVersion nextVersion,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
         {
             var aggregateRootFilter =
                 _filter.Eq(_ => _.EventSource, eventSource.Value)

--- a/Source/Events.Store.MongoDB/Aggregates/IAggregateRoots.cs
+++ b/Source/Events.Store.MongoDB/Aggregates/IAggregateRoots.cs
@@ -29,7 +29,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Aggregates
             ArtifactId aggregateRoot,
             AggregateRootVersion expectedVersion,
             AggregateRootVersion nextVersion,
-            CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Fetches the current version of the aggregate root instance in the event store.
@@ -43,6 +43,6 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Aggregates
             IClientSessionHandle transaction,
             EventSourceId eventSource,
             ArtifactId aggregateRoot,
-            CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken);
     }
 }

--- a/Source/Events.Store.MongoDB/EventHorizon/EventHorizonEventsWriter.cs
+++ b/Source/Events.Store.MongoDB/EventHorizon/EventHorizonEventsWriter.cs
@@ -36,7 +36,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.EventHorizon
         }
 
         /// <inheritdoc/>
-        public async Task Write(CommittedEvent @event, ScopeId scope, CancellationToken cancellationToken = default)
+        public async Task Write(CommittedEvent @event, ScopeId scope, CancellationToken cancellationToken)
         {
             await EventsToStreamsWriter.Write(
                 _connection,

--- a/Source/Events.Store.MongoDB/EventHorizon/EventsFromPublicStreamsFetcher.cs
+++ b/Source/Events.Store.MongoDB/EventHorizon/EventsFromPublicStreamsFetcher.cs
@@ -34,10 +34,10 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.EventHorizon
         }
 
         /// <inheritdoc/>
-        public async Task<Runtime.Events.Streams.StreamEvent> Fetch(StreamId streamId, StreamPosition streamPosition, CancellationToken cancellationToken = default)
+        public async Task<Runtime.Events.Streams.StreamEvent> Fetch(StreamId streamId, StreamPosition streamPosition, CancellationToken cancellationToken)
         {
             var committedEventWithPartition = await EventsFromStreamsFetcher.Fetch(
-                await _connection.GetPublicStreamCollection(streamId).ConfigureAwait(false),
+                await _connection.GetPublicStreamCollection(streamId, cancellationToken).ConfigureAwait(false),
                 _filter,
                 _ => _.StreamPosition,
                 Builders<Events.StreamEvent>.Projection.Expression(_ => _.ToRuntimeStreamEvent(streamId)),
@@ -52,11 +52,11 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.EventHorizon
             Fetch(streamId, streamPosition, cancellationToken);
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<Runtime.Events.Streams.StreamEvent>> FetchRange(StreamId streamId, StreamPositionRange range, CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<Runtime.Events.Streams.StreamEvent>> FetchRange(StreamId streamId, StreamPositionRange range, CancellationToken cancellationToken)
         {
             EventsFromStreamsFetcher.ThrowIfIllegalRange(range);
             return await EventsFromStreamsFetcher.FetchRange(
-                await _connection.GetPublicStreamCollection(streamId).ConfigureAwait(false),
+                await _connection.GetPublicStreamCollection(streamId, cancellationToken).ConfigureAwait(false),
                 _filter,
                 _ => _.StreamPosition,
                 Builders<Events.StreamEvent>.Projection.Expression(_ => _.ToRuntimeStreamEvent(streamId)),
@@ -73,7 +73,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.EventHorizon
         {
             if (partition != PartitionId.NotSet) return ulong.MaxValue;
             return await EventsFromStreamsFetcher.FindNext(
-                await _connection.GetPublicStreamCollection(streamId).ConfigureAwait(false),
+                await _connection.GetPublicStreamCollection(streamId, cancellationToken).ConfigureAwait(false),
                 _filter,
                 _filter.Empty,
                 _ => _.StreamPosition,

--- a/Source/Events.Store.MongoDB/EventHorizon/EventsToPublicStreamsWriter.cs
+++ b/Source/Events.Store.MongoDB/EventHorizon/EventsToPublicStreamsWriter.cs
@@ -33,11 +33,11 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.EventHorizon
         }
 
         /// <inheritdoc/>
-        public Task Write(CommittedEvent @event, StreamId streamId, PartitionId partitionId, CancellationToken cancellationToken = default) =>
+        public Task Write(CommittedEvent @event, StreamId streamId, PartitionId partitionId, CancellationToken cancellationToken) =>
             Write(@event, ScopeId.Default, streamId, partitionId, cancellationToken);
 
         /// <inheritdoc/>
-        public async Task Write(CommittedEvent @event, ScopeId scope, StreamId streamId, PartitionId partitionId, CancellationToken cancellationToken = default)
+        public async Task Write(CommittedEvent @event, ScopeId scope, StreamId streamId, PartitionId partitionId, CancellationToken cancellationToken)
         {
             EventsToStreamsWriter.ThrowIfWritingToAllStream(streamId);
             await EventsToStreamsWriter.Write(

--- a/Source/Events.Store.MongoDB/EventStore.cs
+++ b/Source/Events.Store.MongoDB/EventStore.cs
@@ -49,7 +49,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB
         }
 
         /// <inheritdoc/>
-        public async Task<CommittedEvents> CommitEvents(UncommittedEvents events, CancellationToken cancellationToken = default)
+        public async Task<CommittedEvents> CommitEvents(UncommittedEvents events, CancellationToken cancellationToken)
         {
             ThrowIfNoEventsToCommit(events);
             try
@@ -88,7 +88,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB
         }
 
         /// <inheritdoc/>
-        public async Task<CommittedAggregateEvents> CommitAggregateEvents(UncommittedAggregateEvents events, CancellationToken cancellationToken = default)
+        public async Task<CommittedAggregateEvents> CommitAggregateEvents(UncommittedAggregateEvents events, CancellationToken cancellationToken)
         {
             ThrowIfNoEventsToCommit(events);
             try
@@ -142,7 +142,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB
         }
 
         /// <inheritdoc/>
-        public async Task<CommittedAggregateEvents> FetchForAggregate(EventSourceId eventSource, ArtifactId aggregateRoot, CancellationToken cancellationToken = default)
+        public async Task<CommittedAggregateEvents> FetchForAggregate(EventSourceId eventSource, ArtifactId aggregateRoot, CancellationToken cancellationToken)
         {
             try
             {

--- a/Source/Events.Store.MongoDB/EventStoreConnection.cs
+++ b/Source/Events.Store.MongoDB/EventStoreConnection.cs
@@ -75,7 +75,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB
         /// <param name="stream">The <see cref="StreamId" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The collection.</returns>
-        public Task<IMongoCollection<Events.StreamEvent>> GetStreamCollection(ScopeId scope, StreamId stream, CancellationToken cancellationToken = default) =>
+        public Task<IMongoCollection<Events.StreamEvent>> GetStreamCollection(ScopeId scope, StreamId stream, CancellationToken cancellationToken) =>
             scope == ScopeId.Default ? GetStreamCollection(stream, cancellationToken) : GetScopedStreamCollection(scope, stream, cancellationToken);
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB
         /// <param name="stream">The <see cref="StreamId" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The <see cref="IMongoCollection{StreamEvent}" />.</returns>
-        public async Task<IMongoCollection<Events.StreamEvent>> GetStreamCollection(StreamId stream, CancellationToken cancellationToken = default)
+        public async Task<IMongoCollection<Events.StreamEvent>> GetStreamCollection(StreamId stream, CancellationToken cancellationToken)
         {
             var collection = _connection.Database.GetCollection<Events.StreamEvent>(Constants.CollectionNameForStream(stream));
             await CreateCollectionsAndIndexesForStreamEventsAsync(collection, cancellationToken).ConfigureAwait(false);
@@ -98,7 +98,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB
         /// <param name="stream">The <see cref="StreamId" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The <see cref="IMongoCollection{StreamEvent}" />.</returns>
-        public async Task<IMongoCollection<Events.StreamEvent>> GetScopedStreamCollection(ScopeId scope, StreamId stream, CancellationToken cancellationToken = default)
+        public async Task<IMongoCollection<Events.StreamEvent>> GetScopedStreamCollection(ScopeId scope, StreamId stream, CancellationToken cancellationToken)
         {
             var collection = _connection.Database.GetCollection<Events.StreamEvent>(Constants.CollectionNameForScopedStream(scope, stream));
             await CreateCollectionsAndIndexesForStreamEventsAsync(collection, cancellationToken).ConfigureAwait(false);
@@ -120,7 +120,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB
         /// <param name="scope">The <see cref="ScopeId" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The <see cref="IMongoCollection{StreamEvent}" />.</returns>
-        public async Task<IMongoCollection<Event>> GetScopedEventLog(ScopeId scope, CancellationToken cancellationToken = default)
+        public async Task<IMongoCollection<Event>> GetScopedEventLog(ScopeId scope, CancellationToken cancellationToken)
         {
             var collection = _connection.Database.GetCollection<Event>(Constants.CollectionNameForScopedEventLog(scope));
             await CreateCollectionsAndIndexesForEventLogAsync(collection, cancellationToken).ConfigureAwait(false);
@@ -133,7 +133,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB
         /// <param name="stream">The <see cref="StreamId" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The <see cref="IMongoCollection{StreamEvent}" />.</returns>
-        public async Task<IMongoCollection<Events.StreamEvent>> GetPublicStreamCollection(StreamId stream, CancellationToken cancellationToken = default)
+        public async Task<IMongoCollection<Events.StreamEvent>> GetPublicStreamCollection(StreamId stream, CancellationToken cancellationToken)
         {
             var collection = _connection.Database.GetCollection<Events.StreamEvent>(Constants.CollectionNameForPublicStream(stream));
             await CreateCollectionsAndIndexesForStreamEventsAsync(collection, cancellationToken).ConfigureAwait(false);
@@ -183,7 +183,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB
                     .Ascending(_ => _.TargetStream)));
         }
 
-        async Task CreateCollectionsAndIndexesForStreamEventsAsync(IMongoCollection<Events.StreamEvent> stream, CancellationToken cancellationToken = default)
+        async Task CreateCollectionsAndIndexesForStreamEventsAsync(IMongoCollection<Events.StreamEvent> stream, CancellationToken cancellationToken)
         {
             await stream.Indexes.CreateOneAsync(
                 new CreateIndexModel<MongoDB.Events.StreamEvent>(
@@ -212,7 +212,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB
                 cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
-        async Task CreateCollectionsAndIndexesForEventLogAsync(IMongoCollection<Event> stream, CancellationToken cancellationToken = default)
+        async Task CreateCollectionsAndIndexesForEventLogAsync(IMongoCollection<Event> stream, CancellationToken cancellationToken)
         {
             await stream.Indexes.CreateOneAsync(
                 new CreateIndexModel<Event>(

--- a/Source/Events.Store.MongoDB/Events/EventCommitter.cs
+++ b/Source/Events.Store.MongoDB/Events/EventCommitter.cs
@@ -38,7 +38,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
             Dolittle.Execution.ExecutionContext executionContext,
             Cause cause,
             UncommittedEvent @event,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
         {
             var correlation = executionContext.CorrelationId;
             var microservice = executionContext.Microservice;
@@ -82,7 +82,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
             Execution.ExecutionContext executionContext,
             Cause cause,
             UncommittedEvent @event,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
         {
             var correlation = executionContext.CorrelationId;
             var microservice = executionContext.Microservice;
@@ -131,7 +131,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
             Microservice microservice,
             TenantId tenant,
             Cause cause,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
         {
             try
             {

--- a/Source/Events.Store.MongoDB/Events/IEventCommitter.cs
+++ b/Source/Events.Store.MongoDB/Events/IEventCommitter.cs
@@ -32,7 +32,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
             Dolittle.Execution.ExecutionContext executionContext,
             Cause cause,
             UncommittedEvent @event,
-            CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Commits a single <see cref="UncommittedEvent"/> applied to an event source by an aggregate root to the event log.
@@ -58,6 +58,6 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
             Dolittle.Execution.ExecutionContext executionContext,
             Cause cause,
             UncommittedEvent @event,
-            CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken);
     }
 }

--- a/Source/Events.Store.MongoDB/Processing/Filters/TypePartitionFilterDefinitionRepository.cs
+++ b/Source/Events.Store.MongoDB/Processing/Filters/TypePartitionFilterDefinitionRepository.cs
@@ -31,7 +31,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Processing.Filters
         }
 
         /// <inheritdoc/>
-        public async Task<TypeFilterWithEventSourcePartitionDefinition> GetPersistedFilter(TypeFilterWithEventSourcePartitionDefinition filterDefinition, CancellationToken cancellationToken = default)
+        public async Task<TypeFilterWithEventSourcePartitionDefinition> GetPersistedFilter(TypeFilterWithEventSourcePartitionDefinition filterDefinition, CancellationToken cancellationToken)
         {
             try
             {
@@ -49,7 +49,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Processing.Filters
         }
 
         /// <inheritdoc/>
-        public async Task PersistFilter(TypeFilterWithEventSourcePartitionDefinition filterDefinition, CancellationToken cancellationToken = default)
+        public async Task PersistFilter(TypeFilterWithEventSourcePartitionDefinition filterDefinition, CancellationToken cancellationToken)
         {
             try
             {
@@ -67,7 +67,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Processing.Filters
         }
 
         /// <inheritdoc/>
-        public async Task RemovePersistedFilter(StreamId targetStream, CancellationToken cancellationToken = default)
+        public async Task RemovePersistedFilter(StreamId targetStream, CancellationToken cancellationToken)
         {
             try
             {

--- a/Source/Events.Store.MongoDB/Processing/Streams/StreamProcessorStateRepository.cs
+++ b/Source/Events.Store.MongoDB/Processing/Streams/StreamProcessorStateRepository.cs
@@ -33,7 +33,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Processing.Streams
         }
 
         /// <inheritdoc/>
-        public async Task<Runtime.Events.Processing.Streams.StreamProcessorState> GetOrAddNew(Runtime.Events.Processing.Streams.StreamProcessorId streamProcessorId, CancellationToken cancellationToken = default)
+        public async Task<Runtime.Events.Processing.Streams.StreamProcessorState> GetOrAddNew(Runtime.Events.Processing.Streams.StreamProcessorId streamProcessorId, CancellationToken cancellationToken)
         {
             try
             {
@@ -82,7 +82,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Processing.Streams
         }
 
         /// <inheritdoc/>
-        public async Task<Runtime.Events.Processing.Streams.StreamProcessorState> SetNextEventToProcessPosition(Runtime.Events.Processing.Streams.StreamProcessorId streamProcessorId, StreamPosition position, CancellationToken cancellationToken = default)
+        public async Task<Runtime.Events.Processing.Streams.StreamProcessorState> SetNextEventToProcessPosition(Runtime.Events.Processing.Streams.StreamProcessorId streamProcessorId, StreamPosition position, CancellationToken cancellationToken)
         {
             try
             {
@@ -119,7 +119,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Processing.Streams
             ProcessorFailureType failureType,
             DateTimeOffset retryTime,
             string reason,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
         {
             try
             {
@@ -149,7 +149,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Processing.Streams
         }
 
         /// <inheritdoc/>
-        public async Task<Runtime.Events.Processing.Streams.StreamProcessorState> RemoveFailingPartition(Runtime.Events.Processing.Streams.StreamProcessorId streamProcessorId, PartitionId partitionId, CancellationToken cancellationToken = default)
+        public async Task<Runtime.Events.Processing.Streams.StreamProcessorState> RemoveFailingPartition(Runtime.Events.Processing.Streams.StreamProcessorId streamProcessorId, PartitionId partitionId, CancellationToken cancellationToken)
         {
             try
             {
@@ -180,7 +180,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Processing.Streams
         }
 
         /// <inheritdoc/>
-        public async Task<Runtime.Events.Processing.Streams.StreamProcessorState> SetFailingPartitionState(Runtime.Events.Processing.Streams.StreamProcessorId streamProcessorId, PartitionId partitionId, Runtime.Events.Processing.Streams.FailingPartitionState failingPartitionState, CancellationToken cancellationToken = default)
+        public async Task<Runtime.Events.Processing.Streams.StreamProcessorState> SetFailingPartitionState(Runtime.Events.Processing.Streams.StreamProcessorId streamProcessorId, PartitionId partitionId, Runtime.Events.Processing.Streams.FailingPartitionState failingPartitionState, CancellationToken cancellationToken)
         {
             try
             {

--- a/Source/Events.Store.MongoDB/Streams/AbstractEventTypesFromWellKnownStreamsFetcher.cs
+++ b/Source/Events.Store.MongoDB/Streams/AbstractEventTypesFromWellKnownStreamsFetcher.cs
@@ -28,9 +28,9 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
         public bool CanFetchFromStream(StreamId stream) => WellKnownStreams.Contains(stream);
 
         /// <inheritdoc/>
-        public abstract Task<IEnumerable<Artifact>> FetchTypesInRange(ScopeId scope, StreamId stream, StreamPositionRange range, CancellationToken cancellationToken = default);
+        public abstract Task<IEnumerable<Artifact>> FetchTypesInRange(ScopeId scope, StreamId stream, StreamPositionRange range, CancellationToken cancellationToken);
 
         /// <inheritdoc/>
-        public abstract Task<IEnumerable<Artifact>> FetchTypesInRangeAndPartition(ScopeId scope, StreamId stream, PartitionId partition, StreamPositionRange range, CancellationToken cancellationToken = default);
+        public abstract Task<IEnumerable<Artifact>> FetchTypesInRangeAndPartition(ScopeId scope, StreamId stream, PartitionId partition, StreamPositionRange range, CancellationToken cancellationToken);
     }
 }

--- a/Source/Events.Store.MongoDB/Streams/AbstractEventsFromWellKnownStreamsFetcher.cs
+++ b/Source/Events.Store.MongoDB/Streams/AbstractEventsFromWellKnownStreamsFetcher.cs
@@ -27,12 +27,12 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
         public bool CanFetchFromStream(StreamId stream) => WellKnownStreams.Contains(stream);
 
         /// <inheritdoc/>
-        public abstract Task<StreamEvent> Fetch(ScopeId scope, StreamId streamId, StreamPosition streamPosition, CancellationToken cancellationToken = default);
+        public abstract Task<StreamEvent> Fetch(ScopeId scope, StreamId streamId, StreamPosition streamPosition, CancellationToken cancellationToken);
 
         /// <inheritdoc/>
-        public abstract Task<IEnumerable<StreamEvent>> FetchRange(ScopeId scope, StreamId streamId, StreamPositionRange range, CancellationToken cancellationToken = default);
+        public abstract Task<IEnumerable<StreamEvent>> FetchRange(ScopeId scope, StreamId streamId, StreamPositionRange range, CancellationToken cancellationToken);
 
         /// <inheritdoc/>
-        public abstract Task<StreamPosition> FindNext(ScopeId scope, StreamId streamId, PartitionId partitionId, StreamPosition fromPosition, CancellationToken cancellationToken = default);
+        public abstract Task<StreamPosition> FindNext(ScopeId scope, StreamId streamId, PartitionId partitionId, StreamPosition fromPosition, CancellationToken cancellationToken);
     }
 }

--- a/Source/Events.Store.MongoDB/Streams/EventFromEventLogFetcher.cs
+++ b/Source/Events.Store.MongoDB/Streams/EventFromEventLogFetcher.cs
@@ -33,7 +33,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
         }
 
         /// <inheritdoc/>
-        public override async Task<Runtime.Events.Streams.StreamEvent> Fetch(ScopeId scope, StreamId stream, StreamPosition streamPosition, CancellationToken cancellationToken = default)
+        public override async Task<Runtime.Events.Streams.StreamEvent> Fetch(ScopeId scope, StreamId stream, StreamPosition streamPosition, CancellationToken cancellationToken)
         {
             if (!CanFetchFromStream(stream)) throw new EventsFromWellKnownStreamsFetcherCannotFetchFromStream(this, stream);
             var committedEventWithPartition = await EventsFromStreamsFetcher.Fetch(
@@ -48,7 +48,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
         }
 
         /// <inheritdoc/>
-        public override async Task<IEnumerable<Runtime.Events.Streams.StreamEvent>> FetchRange(ScopeId scope, StreamId stream, StreamPositionRange range, CancellationToken cancellationToken = default)
+        public override async Task<IEnumerable<Runtime.Events.Streams.StreamEvent>> FetchRange(ScopeId scope, StreamId stream, StreamPositionRange range, CancellationToken cancellationToken)
         {
             EventsFromStreamsFetcher.ThrowIfIllegalRange(range);
             if (!CanFetchFromStream(stream)) throw new EventsFromWellKnownStreamsFetcherCannotFetchFromStream(this, stream);
@@ -62,7 +62,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
         }
 
         /// <inheritdoc/>
-        public override async Task<StreamPosition> FindNext(ScopeId scope, StreamId stream, PartitionId partition, StreamPosition fromPosition, CancellationToken cancellationToken = default)
+        public override async Task<StreamPosition> FindNext(ScopeId scope, StreamId stream, PartitionId partition, StreamPosition fromPosition, CancellationToken cancellationToken)
         {
             if (!CanFetchFromStream(stream)) throw new EventsFromWellKnownStreamsFetcherCannotFetchFromStream(this, stream);
             if (partition != PartitionId.NotSet) return ulong.MaxValue;

--- a/Source/Events.Store.MongoDB/Streams/EventTypesFromEventLogFetcher.cs
+++ b/Source/Events.Store.MongoDB/Streams/EventTypesFromEventLogFetcher.cs
@@ -35,11 +35,11 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
         }
 
         /// <inheritdoc/>
-        public override Task<IEnumerable<Artifact>> FetchTypesInRange(ScopeId scope, StreamId stream, StreamPositionRange range, CancellationToken cancellationToken = default) =>
+        public override Task<IEnumerable<Artifact>> FetchTypesInRange(ScopeId scope, StreamId stream, StreamPositionRange range, CancellationToken cancellationToken) =>
             FetchTypesInRangeAndPartition(scope, stream, PartitionId.NotSet, range, cancellationToken);
 
         /// <inheritdoc/>
-        public override async Task<IEnumerable<Artifact>> FetchTypesInRangeAndPartition(ScopeId scope, StreamId stream, PartitionId partition, StreamPositionRange range, CancellationToken cancellationToken = default)
+        public override async Task<IEnumerable<Artifact>> FetchTypesInRangeAndPartition(ScopeId scope, StreamId stream, PartitionId partition, StreamPositionRange range, CancellationToken cancellationToken)
         {
             EventTypesFromStreamsFetcher.ThrowIfIllegalRange(range);
             if (!CanFetchFromStream(stream)) throw new EventTypesFromWellKnownStreamsFetcherCannotFetchFromStream(this, stream);

--- a/Source/Events.Store.MongoDB/Streams/EventTypesFromStreamsFetcher.cs
+++ b/Source/Events.Store.MongoDB/Streams/EventTypesFromStreamsFetcher.cs
@@ -89,7 +89,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
         }
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<Artifact>> FetchTypesInRange(ScopeId scope, StreamId stream, StreamPositionRange range, CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<Artifact>> FetchTypesInRange(ScopeId scope, StreamId stream, StreamPositionRange range, CancellationToken cancellationToken)
         {
             ThrowIfIllegalRange(range);
             if (TryGetFetcher(stream, out var fetcher)) await fetcher.FetchTypesInRange(scope, stream, range, cancellationToken).ConfigureAwait(false);
@@ -104,7 +104,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
         }
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<Artifact>> FetchTypesInRangeAndPartition(ScopeId scope, StreamId stream, PartitionId partition, StreamPositionRange range, CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<Artifact>> FetchTypesInRangeAndPartition(ScopeId scope, StreamId stream, PartitionId partition, StreamPositionRange range, CancellationToken cancellationToken)
         {
             ThrowIfIllegalRange(range);
             if (TryGetFetcher(stream, out var fetcher)) await fetcher.FetchTypesInRangeAndPartition(scope, stream, partition, range, cancellationToken).ConfigureAwait(false);

--- a/Source/Events.Store.MongoDB/Streams/EventsFromStreamsFetcher.cs
+++ b/Source/Events.Store.MongoDB/Streams/EventsFromStreamsFetcher.cs
@@ -157,7 +157,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
         }
 
         /// <inheritdoc/>
-        public async Task<Runtime.Events.Streams.StreamEvent> Fetch(ScopeId scope, StreamId stream, StreamPosition streamPosition, CancellationToken cancellationToken = default)
+        public async Task<Runtime.Events.Streams.StreamEvent> Fetch(ScopeId scope, StreamId stream, StreamPosition streamPosition, CancellationToken cancellationToken)
         {
             if (TryGetFetcher(stream, out var fetcher)) return await fetcher.Fetch(scope, stream, streamPosition, cancellationToken).ConfigureAwait(false);
             var streamEvents = await _connection.GetStreamCollection(scope, stream, cancellationToken).ConfigureAwait(false);
@@ -173,7 +173,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
         }
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<Runtime.Events.Streams.StreamEvent>> FetchRange(ScopeId scope, StreamId stream, StreamPositionRange range, CancellationToken cancellationToken = default)
+        public async Task<IEnumerable<Runtime.Events.Streams.StreamEvent>> FetchRange(ScopeId scope, StreamId stream, StreamPositionRange range, CancellationToken cancellationToken)
         {
             ThrowIfIllegalRange(range);
             if (TryGetFetcher(stream, out var fetcher)) return await fetcher.FetchRange(scope, stream, range, cancellationToken).ConfigureAwait(false);
@@ -188,7 +188,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
         }
 
         /// <inheritdoc/>
-        public async Task<StreamPosition> FindNext(ScopeId scope, StreamId stream, PartitionId partition, StreamPosition fromPosition, CancellationToken cancellationToken = default)
+        public async Task<StreamPosition> FindNext(ScopeId scope, StreamId stream, PartitionId partition, StreamPosition fromPosition, CancellationToken cancellationToken)
         {
             if (TryGetFetcher(stream, out var fetcher)) return await fetcher.FindNext(scope, stream, partition, fromPosition, cancellationToken).ConfigureAwait(false);
             var streamEvents = await _connection.GetStreamCollection(scope, stream, cancellationToken).ConfigureAwait(false);

--- a/Source/Events.Store.MongoDB/Streams/EventsToStreamsWriter.cs
+++ b/Source/Events.Store.MongoDB/Streams/EventsToStreamsWriter.cs
@@ -64,7 +64,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
             ScopeId scope,
             StreamId streamId,
             ArtifactId eventType,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken)
             where TEvent : class
         {
             StreamPosition streamPosition = null;
@@ -118,7 +118,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
         }
 
         /// <inheritdoc/>
-        public async Task Write(CommittedEvent @event, ScopeId scope, StreamId stream, PartitionId partition, CancellationToken cancellationToken = default)
+        public async Task Write(CommittedEvent @event, ScopeId scope, StreamId stream, PartitionId partition, CancellationToken cancellationToken)
         {
             ThrowIfWritingToAllStream(stream);
             await Write(

--- a/Source/Events.Store/ICommitEvents.cs
+++ b/Source/Events.Store/ICommitEvents.cs
@@ -17,7 +17,7 @@ namespace Dolittle.Runtime.Events.Store
         /// <param name="events">The <see cref="UncommittedEvents"/> to be committed.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns><see cref="CommittedEvents"/> corresponding to the <see cref="UncommittedEvents"/> supplied.</returns>
-        Task<CommittedEvents> CommitEvents(UncommittedEvents events, CancellationToken cancellationToken = default);
+        Task<CommittedEvents> CommitEvents(UncommittedEvents events, CancellationToken cancellationToken);
 
         /// <summary>
         /// Commits an <see cref="UncommittedAggregateEvents"/> to the Event Store, returning a corresponding <see cref="CommittedAggregateEvents"/>.
@@ -26,6 +26,6 @@ namespace Dolittle.Runtime.Events.Store
         /// <param name="events">The <see cref="UncommittedAggregateEvents"/> to be committed.</param>
         /// <returns><see cref="CommittedAggregateEvents"/> corresponding to the <see cref="UncommittedAggregateEvents"/> supplied.</returns>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
-        Task<CommittedAggregateEvents> CommitAggregateEvents(UncommittedAggregateEvents events, CancellationToken cancellationToken = default);
+        Task<CommittedAggregateEvents> CommitAggregateEvents(UncommittedAggregateEvents events, CancellationToken cancellationToken);
     }
 }

--- a/Source/Events.Store/IFetchCommittedEvents.cs
+++ b/Source/Events.Store/IFetchCommittedEvents.cs
@@ -19,6 +19,6 @@ namespace Dolittle.Runtime.Events.Store
         /// <param name="aggregateRoot">The <see cref="ArtifactId"/> identifying the Aggregate Root.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The <see cref="CommittedAggregateEvents"/> containing all <see cref="CommittedAggregateEvent"/>s applied to the Event Source by the Aggregate root, in the order of which they appear in the Event Log.</returns>
-        Task<CommittedAggregateEvents> FetchForAggregate(EventSourceId eventSource, ArtifactId aggregateRoot, CancellationToken cancellationToken = default);
+        Task<CommittedAggregateEvents> FetchForAggregate(EventSourceId eventSource, ArtifactId aggregateRoot, CancellationToken cancellationToken);
     }
 }

--- a/Source/Events.Streams/IFetchEventTypesFromStreams.cs
+++ b/Source/Events.Streams/IFetchEventTypesFromStreams.cs
@@ -22,7 +22,7 @@ namespace Dolittle.Runtime.Events.Streams
         /// <param name="range">The <see cref="StreamPositionRange" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The <see cref="IEnumerable{Artifact}" /> event types.</returns>
-        Task<IEnumerable<Artifact>> FetchTypesInRange(ScopeId scope, StreamId streamId, StreamPositionRange range, CancellationToken cancellationToken = default);
+        Task<IEnumerable<Artifact>> FetchTypesInRange(ScopeId scope, StreamId streamId, StreamPositionRange range, CancellationToken cancellationToken);
 
         /// <summary>
         /// Fetch the unique <see cref="Artifact">event types</see> in a an inclusive range in a <see cref="StreamId" /> and <see cref="PartitionId" />.
@@ -33,6 +33,6 @@ namespace Dolittle.Runtime.Events.Streams
         /// <param name="range">The <see cref="StreamPositionRange" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The <see cref="IEnumerable{Artifact}" /> event types.</returns>
-        Task<IEnumerable<Artifact>> FetchTypesInRangeAndPartition(ScopeId scope, StreamId streamId, PartitionId partitionId, StreamPositionRange range, CancellationToken cancellationToken = default);
+        Task<IEnumerable<Artifact>> FetchTypesInRangeAndPartition(ScopeId scope, StreamId streamId, PartitionId partitionId, StreamPositionRange range, CancellationToken cancellationToken);
     }
 }

--- a/Source/Events.Streams/IFetchEventsFromStreams.cs
+++ b/Source/Events.Streams/IFetchEventsFromStreams.cs
@@ -21,7 +21,7 @@ namespace Dolittle.Runtime.Events.Streams
         /// <param name="streamPosition"><see cref="StreamPosition">the position in the stream</see>.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The <see cref="StreamEvent" />.</returns>
-        Task<StreamEvent> Fetch(ScopeId scope, StreamId streamId, StreamPosition streamPosition, CancellationToken cancellationToken = default);
+        Task<StreamEvent> Fetch(ScopeId scope, StreamId streamId, StreamPosition streamPosition, CancellationToken cancellationToken);
 
         /// <summary>
         /// Fetch a range of events in an incluse <see cref="StreamPositionRange" /> in a <see cref="StreamId">stream</see>.
@@ -31,7 +31,7 @@ namespace Dolittle.Runtime.Events.Streams
         /// <param name="range">The <see cref="StreamPositionRange" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The <see cref="IEnumerable{T}" /> of <see cref="StreamEvent" />.</returns>
-        Task<IEnumerable<StreamEvent>> FetchRange(ScopeId scope, StreamId streamId, StreamPositionRange range, CancellationToken cancellationToken = default);
+        Task<IEnumerable<StreamEvent>> FetchRange(ScopeId scope, StreamId streamId, StreamPositionRange range, CancellationToken cancellationToken);
 
         /// <summary>
         /// Gets the <see cref="StreamPosition" /> of the first event in a <see cref="StreamId" >stream</see> in a specific <see cref="PartitionId" /> starting search from the given <see cref="StreamPosition" />..
@@ -43,6 +43,6 @@ namespace Dolittle.Runtime.Events.Streams
         /// <param name="fromPosition">The <see cref="StreamPosition" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The <see cref="StreamPosition" /> of the first event with the given <see cref="PartitionId" /> from the given <see cref="StreamPosition" /> or returns the maximum value of <see cref="StreamPositionRange" /> if .</returns>
-        Task<StreamPosition> FindNext(ScopeId scope, StreamId streamId, PartitionId partitionId, StreamPosition fromPosition, CancellationToken cancellationToken = default);
+        Task<StreamPosition> FindNext(ScopeId scope, StreamId streamId, PartitionId partitionId, StreamPosition fromPosition, CancellationToken cancellationToken);
     }
 }

--- a/Source/Events.Streams/IWriteEventsToStreams.cs
+++ b/Source/Events.Streams/IWriteEventsToStreams.cs
@@ -21,6 +21,6 @@ namespace Dolittle.Runtime.Events.Streams
         /// <param name="partitionId">The <see cref="PartitionId" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>A <see cref="Task"/> representing whether the event was successfully written to the event store.</returns>
-        Task Write(CommittedEvent @event, ScopeId scope, StreamId streamId, PartitionId partitionId, CancellationToken cancellationToken = default);
+        Task Write(CommittedEvent @event, ScopeId scope, StreamId streamId, PartitionId partitionId, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
I also fixed the calls to `new StreamProsessorId()` in `ConcumerClient.cs` and to `_streamProcessorsFactory().Register()` in `Filters.cs`.

I didn't touch the tests so they are still broken. I tried it out with the triple trouble example project and it worked all fine.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1171401530897526)
