### PR TITLE
Simplify IFetchEventTypesFromStreams method names

### DIFF
--- a/Source/Events.Processing/Filters/RemoteFilterValidator.cs
+++ b/Source/Events.Processing/Filters/RemoteFilterValidator.cs
@@ -47,7 +47,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
                 cancellationToken)
                 .ConfigureAwait(false);
             var lastUnProcessedEventPosition = streamProcessorState.Position;
-            var artifactsFromTargetStream = await _eventTypesFromStreams.FetchTypesInRange(
+            var artifactsFromTargetStream = await _eventTypesFromStreams.FetchInRange(
                 filter.Scope,
                 filter.Definition.TargetStream,
                 new StreamPositionRange(StreamPosition.Start, uint.MaxValue),

--- a/Source/Events.Processing/Filters/TypeFilterWithEventSourcePartitionValidator.cs
+++ b/Source/Events.Processing/Filters/TypeFilterWithEventSourcePartitionValidator.cs
@@ -59,7 +59,7 @@ namespace Dolittle.Runtime.Events.Processing.Filters
                     cancellationToken)
                 .ConfigureAwait(false);
             var lastUnProcessedEventPosition = streamProcessorState.Position;
-            var artifactsFromTargetStream = await _eventTypesFromStreams.FetchTypesInRange(
+            var artifactsFromTargetStream = await _eventTypesFromStreams.FetchInRange(
                     filter.Scope,
                     filter.Definition.TargetStream,
                     new StreamPositionRange(StreamPosition.Start, uint.MaxValue),

--- a/Source/Events.Store.MongoDB/Streams/AbstractEventTypesFromWellKnownStreamsFetcher.cs
+++ b/Source/Events.Store.MongoDB/Streams/AbstractEventTypesFromWellKnownStreamsFetcher.cs
@@ -28,9 +28,9 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
         public bool CanFetchFromStream(StreamId stream) => WellKnownStreams.Contains(stream);
 
         /// <inheritdoc/>
-        public abstract Task<IEnumerable<Artifact>> FetchTypesInRange(ScopeId scope, StreamId stream, StreamPositionRange range, CancellationToken cancellationToken);
+        public abstract Task<IEnumerable<Artifact>> FetchInRange(ScopeId scope, StreamId stream, StreamPositionRange range, CancellationToken cancellationToken);
 
         /// <inheritdoc/>
-        public abstract Task<IEnumerable<Artifact>> FetchTypesInRangeAndPartition(ScopeId scope, StreamId stream, PartitionId partition, StreamPositionRange range, CancellationToken cancellationToken);
+        public abstract Task<IEnumerable<Artifact>> FetchInRangeAndPartition(ScopeId scope, StreamId stream, PartitionId partition, StreamPositionRange range, CancellationToken cancellationToken);
     }
 }

--- a/Source/Events.Store.MongoDB/Streams/EventTypesFromEventLogFetcher.cs
+++ b/Source/Events.Store.MongoDB/Streams/EventTypesFromEventLogFetcher.cs
@@ -35,15 +35,15 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
         }
 
         /// <inheritdoc/>
-        public override Task<IEnumerable<Artifact>> FetchTypesInRange(ScopeId scope, StreamId stream, StreamPositionRange range, CancellationToken cancellationToken) =>
-            FetchTypesInRangeAndPartition(scope, stream, PartitionId.NotSet, range, cancellationToken);
+        public override Task<IEnumerable<Artifact>> FetchInRange(ScopeId scope, StreamId stream, StreamPositionRange range, CancellationToken cancellationToken) =>
+            FetchInRangeAndPartition(scope, stream, PartitionId.NotSet, range, cancellationToken);
 
         /// <inheritdoc/>
-        public override async Task<IEnumerable<Artifact>> FetchTypesInRangeAndPartition(ScopeId scope, StreamId stream, PartitionId partition, StreamPositionRange range, CancellationToken cancellationToken)
+        public override async Task<IEnumerable<Artifact>> FetchInRangeAndPartition(ScopeId scope, StreamId stream, PartitionId partition, StreamPositionRange range, CancellationToken cancellationToken)
         {
             if (!CanFetchFromStream(stream)) throw new EventTypesFromWellKnownStreamsFetcherCannotFetchFromStream(this, stream);
             if (partition != PartitionId.NotSet) return Enumerable.Empty<Artifact>();
-            return await EventTypesFromStreamsFetcher.FetchTypesInRange(
+            return await EventTypesFromStreamsFetcher.FetchInRange(
                 await _connection.GetEventLogCollection(scope, cancellationToken).ConfigureAwait(false),
                 _eventLogFilter,
                 _eventLogFilter.Empty,

--- a/Source/Events.Store.MongoDB/Streams/EventTypesFromStreamsFetcher.cs
+++ b/Source/Events.Store.MongoDB/Streams/EventTypesFromStreamsFetcher.cs
@@ -52,7 +52,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
         /// <param name="range">The from <see cref="StreamPosition" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The position of the next event.</returns>
-        public static async Task<IEnumerable<Artifact>> FetchTypesInRange<TEvent>(
+        public static async Task<IEnumerable<Artifact>> FetchInRange<TEvent>(
             IMongoCollection<TEvent> stream,
             FilterDefinitionBuilder<TEvent> filter,
             FilterDefinition<TEvent> eventsInPartitionFilter,
@@ -62,7 +62,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
             CancellationToken cancellationToken)
             where TEvent : class
         {
-             try
+            try
             {
                 var maxNumEvents = range.Length;
                 int? limit = (int)maxNumEvents;
@@ -81,10 +81,14 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
         }
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<Artifact>> FetchTypesInRange(ScopeId scope, StreamId stream, StreamPositionRange range, CancellationToken cancellationToken)
+        public async Task<IEnumerable<Artifact>> FetchInRange(
+            ScopeId scope,
+            StreamId stream,
+            StreamPositionRange range,
+            CancellationToken cancellationToken)
         {
-            if (TryGetFetcher(stream, out var fetcher)) await fetcher.FetchTypesInRange(scope, stream, range, cancellationToken).ConfigureAwait(false);
-            return await FetchTypesInRange(
+            if (TryGetFetcher(stream, out var fetcher)) await fetcher.FetchInRange(scope, stream, range, cancellationToken).ConfigureAwait(false);
+            return await FetchInRange(
                 await _connection.GetStreamCollection(scope, stream, cancellationToken).ConfigureAwait(false),
                 _streamEventFilter,
                 _streamEventFilter.Empty,
@@ -95,10 +99,15 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
         }
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<Artifact>> FetchTypesInRangeAndPartition(ScopeId scope, StreamId stream, PartitionId partition, StreamPositionRange range, CancellationToken cancellationToken)
+        public async Task<IEnumerable<Artifact>> FetchInRangeAndPartition(
+            ScopeId scope,
+            StreamId stream,
+            PartitionId partition,
+            StreamPositionRange range,
+            CancellationToken cancellationToken)
         {
-            if (TryGetFetcher(stream, out var fetcher)) await fetcher.FetchTypesInRangeAndPartition(scope, stream, partition, range, cancellationToken).ConfigureAwait(false);
-            return await FetchTypesInRange(
+            if (TryGetFetcher(stream, out var fetcher)) await fetcher.FetchInRangeAndPartition(scope, stream, partition, range, cancellationToken).ConfigureAwait(false);
+            return await FetchInRange(
                 await _connection.GetStreamCollection(scope, stream, cancellationToken).ConfigureAwait(false),
                 _streamEventFilter,
                 _streamEventFilter.Eq(_ => _.Partition, partition.Value),

--- a/Source/Events.Store/Streams/IFetchEventTypesFromStreams.cs
+++ b/Source/Events.Store/Streams/IFetchEventTypesFromStreams.cs
@@ -21,7 +21,7 @@ namespace Dolittle.Runtime.Events.Store.Streams
         /// <param name="range">The <see cref="StreamPositionRange" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The <see cref="IEnumerable{Artifact}" /> event types.</returns>
-        Task<IEnumerable<Artifact>> FetchTypesInRange(ScopeId scope, StreamId streamId, StreamPositionRange range, CancellationToken cancellationToken);
+        Task<IEnumerable<Artifact>> FetchInRange(ScopeId scope, StreamId streamId, StreamPositionRange range, CancellationToken cancellationToken);
 
         /// <summary>
         /// Fetch the unique <see cref="Artifact">event types</see> in a an inclusive range in a <see cref="StreamId" /> and <see cref="PartitionId" />.
@@ -32,6 +32,6 @@ namespace Dolittle.Runtime.Events.Store.Streams
         /// <param name="range">The <see cref="StreamPositionRange" />.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken" />.</param>
         /// <returns>The <see cref="IEnumerable{Artifact}" /> event types.</returns>
-        Task<IEnumerable<Artifact>> FetchTypesInRangeAndPartition(ScopeId scope, StreamId streamId, PartitionId partitionId, StreamPositionRange range, CancellationToken cancellationToken);
+        Task<IEnumerable<Artifact>> FetchInRangeAndPartition(ScopeId scope, StreamId streamId, PartitionId partitionId, StreamPositionRange range, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
Renamed the interface methods as well as the static overload in `EventTypesFromStreamsFetcher`. 

Multilined some method signatures also as they we're quite long.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1172181905615210)
