### PR TITLE
Remove Id property from StreamProcessorState.

### DIFF
--- a/Source/Events.Store.MongoDB/Processing/Streams/StreamProcessorState.cs
+++ b/Source/Events.Store.MongoDB/Processing/Streams/StreamProcessorState.cs
@@ -12,7 +12,9 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Processing.Streams
 {
     /// <summary>
     /// Represents the state of an <see cref="StreamProcessor" />.
+    /// BsonIgnoreExtraElements is used so that we don't deserialize the '_id' from MongoDB as it's not a property in the class.
     /// </summary>
+    [BsonIgnoreExtraElements]
     public class StreamProcessorState
     {
         /// <summary>
@@ -31,12 +33,6 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Processing.Streams
             Position = position;
             FailingPartitions = failingPartitions;
         }
-
-        /// <summary>
-        /// Gets or sets the  MongoDB _id. This is used so that the class would have a valid '_id' field in mongo.
-        /// The classes 'true' id is comporomised from the combinaton of ScopeId, EventProcessorId and SourceStreamId.
-        /// </summary>
-        public ObjectId Id { get; set; }
 
         /// <summary>
         /// Gets or sets the scope id.


### PR DESCRIPTION
The '_id' field is implicitly created by MongoDB and then with the BsonIgnoreExtraElements we can just ignore it when deserializing.

This is the smart way of dealing with the _id from https://github.com/dolittle-runtime/Runtime/pull/379

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1174066662192291)
