### PR TITLE
Add OriginEventLogSequenceNumber and FromEventHorizon to EventMetadata

### DIFF
--- a/Source/Events.Store.MongoDB/EventHorizon/EventHorizonEventsWriter.cs
+++ b/Source/Events.Store.MongoDB/EventHorizon/EventHorizonEventsWriter.cs
@@ -45,6 +45,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.EventHorizon
                 cancellationToken).ConfigureAwait(false);
         }
 
+        // TODO add OriginSequenceNumber to GRPC so that we can use it
         MongoDB.Events.Event CreateEventFromEventHorizonEvent(CommittedEvent @event, EventLogSequenceNumber sequenceNumber) =>
             new MongoDB.Events.Event(
                 sequenceNumber,
@@ -54,7 +55,9 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.EventHorizon
                     @event.EventSource,
                     @event.Type.Id,
                     @event.Type.Generation,
-                    @event.Public),
+                    @event.Public,
+                    true,
+                    sequenceNumber),
                 new AggregateMetadata(),
                 BsonDocument.Parse(@event.Content));
     }

--- a/Source/Events.Store.MongoDB/Events/EventCommitter.cs
+++ b/Source/Events.Store.MongoDB/Events/EventCommitter.cs
@@ -116,7 +116,9 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
                         eventSource,
                         @event.Type.Id,
                         @event.Type.Generation,
-                        @event.Public),
+                        @event.Public,
+                        false,
+                        version),
                     aggregate,
                     BsonDocument.Parse(@event.Content)),
                 cancellationToken: cancellationToken);

--- a/Source/Events.Store.MongoDB/Events/EventExtensions.cs
+++ b/Source/Events.Store.MongoDB/Events/EventExtensions.cs
@@ -23,7 +23,9 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
                 committedEvent.EventSource,
                 committedEvent.Type.Id,
                 committedEvent.Type.Generation,
-                committedEvent.Public);
+                committedEvent.Public,
+                false,
+                committedEvent.EventLogSequenceNumber);
 
         /// <summary>
         /// Converts a <see cref="Event" /> to <see cref="CommittedAggregateEvent" />.

--- a/Source/Events.Store.MongoDB/Events/EventMetadata.cs
+++ b/Source/Events.Store.MongoDB/Events/EventMetadata.cs
@@ -21,13 +21,24 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
         /// <param name="typeId">The id of the event artifact type.</param>
         /// <param name="typeGeneration">The generation of the event artifact.</param>
         /// <param name="isPublic">Whether the Event is public.</param>
-        public EventMetadata(DateTimeOffset occurred, Guid eventSource, Guid typeId, uint typeGeneration, bool isPublic)
+        /// <param name="fromEventHorizon">Wether the Event is from an EventHorizon.</param>
+        /// <param name="originEventLogSequenceNumber">The Event's original event log sequence number if it came from EventHorizon.</param>
+        public EventMetadata(
+            DateTimeOffset occurred,
+            Guid eventSource,
+            Guid typeId,
+            uint typeGeneration,
+            bool isPublic,
+            bool fromEventHorizon,
+            ulong originEventLogSequenceNumber)
         {
             Occurred = occurred;
             EventSource = eventSource;
             TypeId = typeId;
             TypeGeneration = typeGeneration;
             Public = isPublic;
+            FromEventHorizon = fromEventHorizon;
+            OriginEventLogSequenceNumber = originEventLogSequenceNumber;
         }
 
         /// <summary>
@@ -61,5 +72,16 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
         /// Gets or sets a value indicating whether this is a public Event.
         /// </summary>
         public bool Public { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this event came from EventHorizon.
+        /// </summary>
+        public bool FromEventHorizon { get; set; }
+
+        /// <summary>
+        /// Gets or sets the origin event log sequence number of the event if it came from EventHorizon.
+        /// </summary>
+        [BsonRepresentation(BsonType.Decimal128)]
+        public ulong OriginEventLogSequenceNumber { get; set; }
     }
 }

--- a/Source/Events.Store.MongoDB/Events/StreamEventExtensions.cs
+++ b/Source/Events.Store.MongoDB/Events/StreamEventExtensions.cs
@@ -24,7 +24,9 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
                 committedEvent.EventSource,
                 committedEvent.Type.Id,
                 committedEvent.Type.Generation,
-                committedEvent.Public);
+                committedEvent.Public,
+                false,
+                committedEvent.EventLogSequenceNumber);
 
         /// <summary>
         /// Converts a <see cref="Event" /> to <see cref="CommittedAggregateEvent" />.

--- a/Source/Events.Store.MongoDB/Events/StreamEventMetadata.cs
+++ b/Source/Events.Store.MongoDB/Events/StreamEventMetadata.cs
@@ -21,8 +21,10 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
         /// <param name="typeId">The id of the event artifact type.</param>
         /// <param name="typeGeneration">The generation of the event artifact.</param>
         /// <param name="isPublic">Whether the Event is public.</param>
-        public StreamEventMetadata(ulong eventLogSequenceNumber, DateTimeOffset occurred, Guid eventSource, Guid typeId, uint typeGeneration, bool isPublic)
-            : base(occurred, eventSource, typeId, typeGeneration, isPublic)
+        /// <param name="fromEventHorizon">Wether the Event is from an EventHorizon.</param>
+        /// <param name="originEventLogSequenceNumber">The Event's original event log sequence number if it came from EventHorizon.</param>
+        public StreamEventMetadata(ulong eventLogSequenceNumber, DateTimeOffset occurred, Guid eventSource, Guid typeId, uint typeGeneration, bool isPublic, bool fromEventHorizon, ulong originEventLogSequenceNumber)
+            : base(occurred, eventSource, typeId, typeGeneration, isPublic, fromEventHorizon, originEventLogSequenceNumber)
         {
             EventLogSequenceNumber = eventLogSequenceNumber;
         }


### PR DESCRIPTION
Do note that as we don't yet transport the origin sequence number over grpc the `EventMetaData.OriginEventLogSequenceNumber` will be same as the events `EventLogSequenceNumber`.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1175370478549746)
