### PR TITLE
Remove default scoped subscription-states collection

### DIFF
--- a/Source/Events.Store.MongoDB/Constants.cs
+++ b/Source/Events.Store.MongoDB/Constants.cs
@@ -36,11 +36,6 @@ namespace Dolittle.Runtime.Events.Store.MongoDB
         public const string StreamDefinitionCollection = "stream-definitions";
 
         /// <summary>
-        /// The collection name for subscription states.
-        /// </summary>
-        public const string SubscriptionStateCollection = "subscription-states";
-
-        /// <summary>
         /// Gets the collection name for a stream.
         /// </summary>
         /// <param name="streamId">The <see cref="StreamId" />.</param>
@@ -88,6 +83,6 @@ namespace Dolittle.Runtime.Events.Store.MongoDB
         /// </summary>
         /// <param name="scope">The <see cref="ScopeId" />.</param>
         /// <returns>The scoped SubscriptionStateCollection name.</returns>
-        public static string CollectionNameForScopedSubscriptionStates(ScopeId scope) => $"x-{scope}-{SubscriptionStateCollection}";
+        public static string CollectionNameForScopedSubscriptionStates(ScopeId scope) => $"x-{scope}-subscription-states";
     }
 }

--- a/Source/Events.Store.MongoDB/Processing/Streams/StreamProcessorStates.cs
+++ b/Source/Events.Store.MongoDB/Processing/Streams/StreamProcessorStates.cs
@@ -49,7 +49,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Processing.Streams
             {
                 if (id is SubscriptionId subscriptionId)
                 {
-                    var states = await _connection.GetSubscriptionStateCollection(subscriptionId.ScopeId, cancellationToken).ConfigureAwait(false);
+                    var states = await _connection.GetScopedSubscriptionStateCollection(subscriptionId.ScopeId, cancellationToken).ConfigureAwait(false);
                     var persistedState = await states.Find(CreateFilter(subscriptionId))
                         .FirstOrDefaultAsync(cancellationToken)
                         .ConfigureAwait(false);
@@ -104,7 +104,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Processing.Streams
                             streamProcessorState.ProcessingAttempts,
                             streamProcessorState.LastSuccessfullyProcessed,
                             streamProcessorState.IsFailing);
-                        var states = await _connection.GetSubscriptionStateCollection(subscriptionId.ScopeId, cancellationToken).ConfigureAwait(false);
+                        var states = await _connection.GetScopedSubscriptionStateCollection(subscriptionId.ScopeId, cancellationToken).ConfigureAwait(false);
                         var persistedState = await states.ReplaceOneAsync(
                             CreateFilter(subscriptionId),
                             replacementState,


### PR DESCRIPTION
Removed the `GetSubscriptionStateCollection`, the new default is `GetScopedSubscriptionStateCollection` as subscription states are always scoped.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1175371654345108)
