### PR TITLE
Add Partitioned property to Runtime's StreamEvents

### DIFF
--- a/Source/EventHorizon/Consumer/ConsumerClient.cs
+++ b/Source/EventHorizon/Consumer/ConsumerClient.cs
@@ -273,7 +273,8 @@ namespace Dolittle.Runtime.EventHorizon.Consumer
                         @event.ToCommittedEvent(subscriptionId.ProducerMicroserviceId, subscriptionId.ConsumerTenantId),
                         @event.StreamSequenceNumber,
                         StreamId.EventLog,
-                        Guid.Empty),
+                        Guid.Empty,
+                        false),
                     cancellationToken).ConfigureAwait(false);
             }
         }

--- a/Source/Events.Store.MongoDB/Events/EventExtensions.cs
+++ b/Source/Events.Store.MongoDB/Events/EventExtensions.cs
@@ -63,8 +63,9 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
         /// Converts a <see cref="Event" /> to a <see cref="Store.Streams.StreamEvent" />.
         /// </summary>
         /// <param name="event">The <see cref="Event" />.</param>
+        /// <param name="partitioned">Whether the event is partitioned.</param>
         /// <returns>The converted <see cref="Store.Streams.StreamEvent" />.</returns>
-        public static Store.Streams.StreamEvent ToRuntimeStreamEvent(this Event @event) =>
-            new Store.Streams.StreamEvent(@event.ToCommittedEvent(), @event.EventLogSequenceNumber, StreamId.EventLog, Guid.Empty);
+        public static Store.Streams.StreamEvent ToRuntimeStreamEvent(this Event @event, bool partitioned) =>
+            new Store.Streams.StreamEvent(@event.ToCommittedEvent(), @event.EventLogSequenceNumber, StreamId.EventLog, Guid.Empty, partitioned);
     }
 }

--- a/Source/Events.Store.MongoDB/Events/StreamEventExtensions.cs
+++ b/Source/Events.Store.MongoDB/Events/StreamEventExtensions.cs
@@ -65,9 +65,10 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Events
         /// </summary>
         /// <param name="event">The <see cref="Event" />.</param>
         /// <param name="stream">The <see cref="StreamId" />.</param>
+        /// <param name="partitioned">Whether the <see cref="StreamEvent"/> is partitioned.</param>
         /// <returns>The converted <see cref="StreamEvent" />.</returns>
-        public static Store.Streams.StreamEvent ToRuntimeStreamEvent(this MongoDB.Events.StreamEvent @event, StreamId stream) =>
-            new Store.Streams.StreamEvent(@event.ToCommittedEvent(), @event.StreamPosition, stream, @event.Partition);
+        public static Store.Streams.StreamEvent ToRuntimeStreamEvent(this MongoDB.Events.StreamEvent @event, StreamId stream, bool partitioned) =>
+            new Store.Streams.StreamEvent(@event.ToCommittedEvent(), @event.StreamPosition, stream, @event.Partition, partitioned);
 
         /// <summary>
         /// Converts a <see cref="CommittedEvent" /> to <see cref="Event" />.

--- a/Source/Events.Store.MongoDB/Streams/EventFetchers.cs
+++ b/Source/Events.Store.MongoDB/Streams/EventFetchers.cs
@@ -37,12 +37,14 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
             {
                 return CreateStreamFetcherForStreamEventCollection(
                     await _connection.GetPublicStreamCollection(streamDefinition.StreamId, cancellationToken).ConfigureAwait(false),
-                    streamDefinition.StreamId);
+                    streamDefinition.StreamId,
+                    streamDefinition.Partitioned);
             }
 
             return CreateStreamFetcherForStreamEventCollection(
                 await _connection.GetStreamCollection(scopeId, streamDefinition.StreamId, cancellationToken).ConfigureAwait(false),
-                streamDefinition.StreamId);
+                streamDefinition.StreamId,
+                streamDefinition.Partitioned);
         }
 
         /// <inheritdoc/>
@@ -54,12 +56,14 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
             {
                 return CreateStreamFetcherForStreamEventCollection(
                     await _connection.GetPublicStreamCollection(streamDefinition.StreamId, cancellationToken).ConfigureAwait(false),
-                    streamDefinition.StreamId);
+                    streamDefinition.StreamId,
+                    streamDefinition.Partitioned);
             }
 
             return CreateStreamFetcherForStreamEventCollection(
                 await _connection.GetStreamCollection(scopeId, streamDefinition.StreamId, cancellationToken).ConfigureAwait(false),
-                streamDefinition.StreamId);
+                streamDefinition.StreamId,
+                streamDefinition.Partitioned);
         }
 
         /// <inheritdoc/>
@@ -85,15 +89,15 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Streams
                 await _connection.GetEventLogCollection(scopeId, cancellationToken).ConfigureAwait(false),
                 Builders<MongoDB.Events.Event>.Filter,
                 _ => _.EventLogSequenceNumber,
-                Builders<MongoDB.Events.Event>.Projection.Expression(_ => _.ToRuntimeStreamEvent()),
+                Builders<MongoDB.Events.Event>.Projection.Expression(_ => _.ToRuntimeStreamEvent(false)),
                 Builders<MongoDB.Events.Event>.Projection.Expression(_ => new Artifacts.Artifact(_.Metadata.TypeId, _.Metadata.TypeGeneration)));
 
-        StreamFetcher<MongoDB.Events.StreamEvent> CreateStreamFetcherForStreamEventCollection(IMongoCollection<MongoDB.Events.StreamEvent> collection, StreamId streamId) =>
+        StreamFetcher<MongoDB.Events.StreamEvent> CreateStreamFetcherForStreamEventCollection(IMongoCollection<MongoDB.Events.StreamEvent> collection, StreamId streamId, bool partitioned) =>
             new StreamFetcher<MongoDB.Events.StreamEvent>(
                 collection,
                 Builders<MongoDB.Events.StreamEvent>.Filter,
                 _ => _.StreamPosition,
-                Builders<MongoDB.Events.StreamEvent>.Projection.Expression(_ => _.ToRuntimeStreamEvent(streamId)),
+                Builders<MongoDB.Events.StreamEvent>.Projection.Expression(_ => _.ToRuntimeStreamEvent(streamId, partitioned)),
                 Builders<MongoDB.Events.StreamEvent>.Projection.Expression(_ => new Artifacts.Artifact(_.Metadata.TypeId, _.Metadata.TypeGeneration)),
                 _ => _.Partition);
     }

--- a/Source/Events.Store/Streams/StreamEvent.cs
+++ b/Source/Events.Store/Streams/StreamEvent.cs
@@ -17,12 +17,14 @@ namespace Dolittle.Runtime.Events.Store.Streams
         /// <param name="position">The <see cref="StreamPosition" />.</param>
         /// <param name="stream">The <see cref="StreamId" />.</param>
         /// <param name="partition">The <see cref="PartitionId" />.</param>
-        public StreamEvent(CommittedEvent @event, StreamPosition position, StreamId stream, PartitionId partition)
+        /// <param name="partitioned">Whether the event is partitioned.</param>
+        public StreamEvent(CommittedEvent @event, StreamPosition position, StreamId stream, PartitionId partition, bool partitioned)
         {
             Event = @event;
             Position = position;
             Stream = stream;
             Partition = partition;
+            Partitioned = partitioned;
         }
 
         /// <summary>
@@ -44,5 +46,10 @@ namespace Dolittle.Runtime.Events.Store.Streams
         /// Gets the <see cref="PartitionId">partition </see> that this event belongs to.
         /// </summary>
         public PartitionId Partition { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the StreamEvent is partitioned.
+        /// </summary>
+        public bool Partitioned { get; }
     }
 }

--- a/Source/Events.Store/Streams/StreamEvent.cs
+++ b/Source/Events.Store/Streams/StreamEvent.cs
@@ -48,7 +48,7 @@ namespace Dolittle.Runtime.Events.Store.Streams
         public PartitionId Partition { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the StreamEvent is partitioned.
+        /// Gets a value indicating whether the <see cref="StreamEvent"/> is partitioned.
         /// </summary>
         public bool Partitioned { get; }
     }


### PR DESCRIPTION
Also fixed the calls to the constructor, adding the correct bool depending on the context.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1175570932330942)
