### PR TITLE
Uncaught exception in SubscriptionService

### DIFF
--- a/Source/Events.Store.MongoDB/Bindings.cs
+++ b/Source/Events.Store.MongoDB/Bindings.cs
@@ -25,6 +25,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB
             builder.Bind<IStreamDefinitionRepository>().To<StreamDefinitionRepository>();
             builder.Bind<IEventFetchers>().To<EventFetchers>();
             builder.Bind<IWriteEventsToStreams>().To<EventsToStreamsWriter>();
+            builder.Bind<IWriteEventsToStreamCollection>().To<EventsToStreamsWriter>();
             builder.Bind<IWriteEventHorizonEvents>().To<EventHorizonEventsWriter>();
             builder.Bind<IWriteEventsToPublicStreams>().To<EventsToPublicStreamsWriter>();
         }


### PR DESCRIPTION
There was a missing binding in `Bindings.cs` which caused Autofac to fail inside the statement:
```csharp
var subscriptionResponse = await _getConsumerClient().HandleSubscription(subscriptionId).ConfigureAwait(false);
```

This exception wasn't caught anywhere so this PR adds logging for future exceptions.

What should be the `FailureId` for the response and the message? Should the whole `subscriptionRequest` be logged in runtime?

Ref:
https://github.com/dolittle-fundamentals/DotNET.Fundamentals/pull/318

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1176011931025601)
