### PR TITLE
Fix stream processor state discriminator convention

### DIFF
--- a/Source/Events.Store.MongoDB/Processing/Streams/StreamProcessorStateDiscriminatorConvention.cs
+++ b/Source/Events.Store.MongoDB/Processing/Streams/StreamProcessorStateDiscriminatorConvention.cs
@@ -69,7 +69,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Processing.Streams
 
         void ThrowIfNominalTypeIsIncorrect(Type nominalType)
         {
-            if (nominalType != typeof(AbstractStreamProcessorState))
+            if (!typeof(AbstractStreamProcessorState).IsAssignableFrom(nominalType))
                 throw new UnsupportedTypeForStreamProcessorStateDiscriminatorConvention(nominalType);
         }
     }

--- a/Source/Events.Store.MongoDB/Processing/Streams/UnsupportedTypeForStreamProcessorStateDiscriminatorConvention.cs
+++ b/Source/Events.Store.MongoDB/Processing/Streams/UnsupportedTypeForStreamProcessorStateDiscriminatorConvention.cs
@@ -15,7 +15,7 @@ namespace Dolittle.Runtime.Events.Store.MongoDB.Processing.Streams
         /// </summary>
         /// <param name="type">Nominal type used in the discriminator convention.</param>
         public UnsupportedTypeForStreamProcessorStateDiscriminatorConvention(Type type)
-            : base($"Type: {type} isn't derived from AbstractStreamProcessorState and is not supported by StreamProcessorStateDiscriminatorConvention. Was this type erroneously registered with BsonSerializer.RegisterDiscriminatorConvention?", null)
+            : base($"Type: {type} isn't derived from {typeof(AbstractStreamProcessorState)} and is not supported by {typeof(StreamProcessorStateDiscriminatorConvention)}. Was this type erroneously registered with BsonSerializer.RegisterDiscriminatorConvention?", null)
         {
         }
     }


### PR DESCRIPTION
Bug in the ThrowIfNominalTypeIsIncorrect-method. Check whether the AbstractStreamProcessorState is assignable from the nominal type.

Also use the Type.ToString in the exception message

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1177055742225598)
